### PR TITLE
added readonly keyword to avoid copying this struct

### DIFF
--- a/BepuPhysics/Collidables/Mesh.cs
+++ b/BepuPhysics/Collidables/Mesh.cs
@@ -384,7 +384,7 @@ namespace BepuPhysics.Collidables
         /// </summary>
         /// <param name="mass">Mass to scale the inertia tensor with.</param>
         /// <param name="inertia">Inertia of the closed mesh.</param>
-        public void ComputeClosedInertia(float mass, out BodyInertia inertia)
+        public readonly void ComputeClosedInertia(float mass, out BodyInertia inertia)
         {
             var triangleSource = new MeshTriangleSource(this);
             MeshInertiaHelper.ComputeClosedInertia(ref triangleSource, mass, out _, out var inertiaTensor);


### PR DESCRIPTION
since you are testing net5, I would like to see stuff like this fixed.
![evwefwef3](https://user-images.githubusercontent.com/43344410/123561304-f049e780-d7c0-11eb-9bd4-0c073d1003d3.PNG)
It's enough to add readonly keyword, but it's a C#8.0 feature.
You can test [this example code](https://pastebin.com/eBMXWnxG) in https://sharplab.io/ to see what id does.