### PR TITLE
Add setters for NodeCount and LeafCount

### DIFF
--- a/BepuPhysics/Trees/Tree.cs
+++ b/BepuPhysics/Trees/Tree.cs
@@ -11,21 +11,29 @@ namespace BepuPhysics.Trees
         public Buffer<Node> Nodes;
         public Buffer<Metanode> Metanodes;
         int nodeCount;
-        public readonly int NodeCount
+        public int NodeCount
         {
-            get
+            readonly get
             {
                 return nodeCount;
+            }
+            set
+            {
+                nodeCount = value;
             }
         }
 
         public Buffer<Leaf> Leaves;
         int leafCount;
-        public readonly int LeafCount
+        public int LeafCount
         {
-            get
+            readonly get
             {
                 return leafCount;
+            }
+            set
+            {
+                leafCount = value;
             }
         }
 


### PR DESCRIPTION
Another small change that should (hopefully) be ok to merge!

I'm doing custom serialization for Trees in my code, but without ability to set the Node/LeafCount, I can't actually deserialize them properly, even though I can deserialize all the buffers.

This exposes the setter, which can be spooky to modify externally, but I figure a lot of the other stuff is as well :D