### PR TITLE
Fixed TimestepsUnderThresholdCount potentially overflowing

### DIFF
--- a/BepuPhysics/PoseIntegrator.cs
+++ b/BepuPhysics/PoseIntegrator.cs
@@ -198,10 +198,13 @@ namespace BepuPhysics
             }
             else
             {
-                ++activity.TimestepsUnderThresholdCount;
-                if (activity.TimestepsUnderThresholdCount >= activity.MinimumTimestepsUnderThreshold)
+                if (activity.TimestepsUnderThresholdCount < byte.MaxValue)
                 {
-                    activity.SleepCandidate = true;
+                    ++activity.TimestepsUnderThresholdCount;
+                    if (activity.TimestepsUnderThresholdCount >= activity.MinimumTimestepsUnderThreshold)
+                    {
+                        activity.SleepCandidate = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
Last of the small changes I made on my end for your consideration! :D

While I was poking around the sleeping issue, I noticed that a bunch of the bodies would not have any velocity to wake up, but would eventually wrap and start counting from 0.

I don't think it causes a big issue now as the bodies sleep before it can reach that high, but I figure the fix might be good to have in there regardless.