### PR TITLE
Fix contact manifolds are sometimes not created when a mesh had a collision

### DIFF
--- a/BepuPhysics/CollisionDetection/CollisionTasks/BoxConvexHullTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/BoxConvexHullTester.cs
@@ -27,7 +27,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             initialNormal.Z = Vector.ConditionalSelect(useInitialFallback, Vector<float>.Zero, initialNormal.Z);
             var hullSupportFinder = default(ConvexHullSupportFinder);
             var boxSupportFinder = default(BoxSupportFinder);
-            ManifoldCandidateHelper.CreateInactiveMask(pairCount, out var inactiveLanes);
+            var inactiveLanes = BundleIndexing.CreateTrailingMaskForCountInBundle(pairCount);
             b.EstimateEpsilonScale(inactiveLanes, out var hullEpsilonScale);
             var epsilonScale = Vector.Min(Vector.Max(a.HalfWidth, Vector.Max(a.HalfHeight, a.HalfLength)), hullEpsilonScale);
             var depthThreshold = -speculativeMargin;
@@ -156,9 +156,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                     var denominator = edgePlaneNormalX * hullEdgeOffsetX + edgePlaneNormalY * hullEdgeOffsetY + edgePlaneNormalZ * hullEdgeOffsetZ;
                     var edgeIntersections = numerator / denominator;
 
-
                     //A plane is being 'entered' if the ray direction opposes the face normal.
                     //Entry denominators are always negative, exit denominators are always positive. Don't have to worry about comparison sign flips.
+                    //TODO: Now that we're off NS2.0, this branchmess could be improved.
                     float latestEntry, earliestExit;
                     if (denominator.X < 0)
                     {
@@ -170,8 +170,15 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                         latestEntry = float.MinValue;
                         earliestExit = edgeIntersections.X;
                     }
+                    else if (numerator.X < 0)
+                    {
+                        //The B edge is parallel and outside the edge A, so there can be no intersection.
+                        earliestExit = float.MinValue;
+                        latestEntry = float.MaxValue;
+                    }
                     else
                     {
+                        //Parallel, but inside.
                         latestEntry = float.MinValue;
                         earliestExit = float.MaxValue;
                     }
@@ -185,6 +192,11 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                         if (edgeIntersections.Y < earliestExit)
                             earliestExit = edgeIntersections.Y;
                     }
+                    else if (numerator.Y < 0)
+                    {
+                        earliestExit = float.MinValue;
+                        latestEntry = float.MaxValue;
+                    }
                     if (denominator.Z < 0)
                     {
                         if (edgeIntersections.Z > latestEntry)
@@ -195,6 +207,11 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                         if (edgeIntersections.Z < earliestExit)
                             earliestExit = edgeIntersections.Z;
                     }
+                    else if (numerator.Z < 0)
+                    {
+                        earliestExit = float.MinValue;
+                        latestEntry = float.MaxValue;
+                    }
                     if (denominator.W < 0)
                     {
                         if (edgeIntersections.W > latestEntry)
@@ -204,6 +221,11 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                     {
                         if (edgeIntersections.W < earliestExit)
                             earliestExit = edgeIntersections.W;
+                    }
+                    else if (numerator.W < 0)
+                    {
+                        earliestExit = float.MinValue;
+                        latestEntry = float.MaxValue;
                     }
 
                     //We now have a convex hull edge interval. Add contacts for it.
@@ -308,7 +330,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 Vector3Wide.ReadSlot(ref boxFaceNormal, slotIndex, out var slotBoxFaceNormal);
                 Vector3Wide.ReadSlot(ref offsetB, slotIndex, out var slotOffsetB);
                 Matrix3x3Wide.ReadSlot(ref hullOrientation, slotIndex, out var slotHullOrientation);
-                ManifoldCandidateHelper.Reduce(candidates, candidateCount, slotBoxFaceNormal, slotLocalNormal, slotBoxFaceCenter, hullFaceOrigin, hullFaceX, hullFaceY, epsilonScale[slotIndex], depthThreshold[slotIndex],
+                ManifoldCandidateHelper.Reduce(candidates, candidateCount, slotBoxFaceNormal, 1f / Vector3.Dot(slotBoxFaceNormal, slotLocalNormal), slotBoxFaceCenter, hullFaceOrigin, hullFaceX, hullFaceY, epsilonScale[slotIndex], depthThreshold[slotIndex],
                    slotHullOrientation, slotOffsetB, slotIndex, ref manifold);
             }
             //The reduction does not assign the normal. Fill it in.

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleTriangleTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleTriangleTester.cs
@@ -11,7 +11,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
     {
         public int BatchSize => 32;
 
-        public static void TestEdge(in TriangleWide triangle, in Vector3Wide triangleCenter, in Vector3Wide triangleNormal,
+        public static void TestEdge(in TriangleWide triangle, in Vector3Wide triangleNormal,
             in Vector3Wide edgeStart, in Vector3Wide edgeOffset,
             in Vector3Wide capsuleCenter, in Vector3Wide capsuleAxis, in Vector<float> capsuleHalfLength,
             out Vector3Wide edgeDirection, out Vector<float> ta, out Vector<float> tb, out Vector<float> bMin, out Vector<float> bMax, out Vector<float> depth, out Vector3Wide normal)
@@ -68,11 +68,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             var useSecondFallbackNormal = Vector.LessThan(normalLengthSquared, new Vector<float>(1e-15f));
             Vector3Wide.ConditionalSelect(useSecondFallbackNormal, secondFallbackNormal, normal, out normal);
             normalLengthSquared = Vector.ConditionalSelect(useSecondFallbackNormal, secondFallbackNormalLengthSquared, normalLengthSquared);
-            //Calibrate the normal to point from the triangle to the capsule. Note that this may not be the same direction as the *edge* to the capsule.
-            Vector3Wide.Subtract(capsuleCenter, triangleCenter, out var ba);
-            Vector3Wide.Dot(normal, ba, out var normalBA);
-            var numerator = Vector.ConditionalSelect(Vector.LessThan(normalBA, Vector<float>.Zero), new Vector<float>(-1f), Vector<float>.One);
-            Vector3Wide.Scale(normal, numerator / Vector.SquareRoot(normalLengthSquared), out normal);
+            //Note that we DO NOT 'calibrate' the normal here! The edge winding should avoid the need for any calibration,
+            //and attempting to calibrate this normal can actually result in normals pointing into the triangle face.
+            //That can cause backfaces to generate contacts incorrectly.
+            Vector3Wide.Scale(normal, Vector<float>.One / Vector.SquareRoot(normalLengthSquared), out normal);
 
             //Note that the normal between the closest points is not necessarily perpendicular to both the edge and capsule axis due to clamping, so to compute depth
             //we need to include the extent of both.
@@ -114,11 +113,18 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         {
             //Work in the triangle's local space to limit transformation requirements.
             Matrix3x3Wide.CreateFromQuaternion(orientationB, out var rB);
-            Matrix3x3Wide.TransformByTransposedWithoutOverlap(offsetB, rB, out var localOffsetB);
-            Vector3Wide.Negate(localOffsetB, out var localOffsetA);
             Vector3Wide.Add(b.A, b.B, out var localTriangleCenter);
             Vector3Wide.Add(b.C, localTriangleCenter, out localTriangleCenter);
             Vector3Wide.Scale(localTriangleCenter, new Vector<float>(1f / 3f), out localTriangleCenter);
+            //Note that we're not just using the same origin as the triangle, but using the center of the triangle as the origin of the working space.
+            //This helps avoid some numerical issues.
+            Matrix3x3Wide.TransformByTransposedWithoutOverlap(offsetB, rB, out var localOffsetB);
+            Vector3Wide.Add(localOffsetB, localTriangleCenter, out localOffsetB);
+            Vector3Wide.Negate(localOffsetB, out var localOffsetA);
+            TriangleWide triangle;
+            Vector3Wide.Subtract(b.A, localTriangleCenter, out triangle.A);
+            Vector3Wide.Subtract(b.B, localTriangleCenter, out triangle.B);
+            Vector3Wide.Subtract(b.C, localTriangleCenter, out triangle.C);
 
             QuaternionWide.TransformUnitY(orientationA, out var worldCapsuleAxis);
             Matrix3x3Wide.TransformByTransposedWithoutOverlap(worldCapsuleAxis, rB, out var localCapsuleAxis);
@@ -144,20 +150,20 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Vector3Wide.Subtract(b.B, b.A, out var ab);
 
             Vector3Wide.CrossWithoutOverlap(ac, ab, out var acxab);
-            Vector3Wide.LengthSquared(acxab, out var faceNormalLengthSquared);
-            Vector3Wide.Scale(acxab, Vector<float>.One / Vector.SquareRoot(faceNormalLengthSquared), out var faceNormal);
+            Vector3Wide.Length(acxab, out var faceNormalLength);
+            Vector3Wide.Scale(acxab, Vector<float>.One / faceNormalLength, out var faceNormal);
 
-            Vector3Wide.Subtract(localOffsetA, localTriangleCenter, out var triangleCenterToCapsuleCenter);
             //The depth along the face normal is unaffected by the triangle's extent- the triangle has no extent along its own normal. But the capsule does.
             Vector3Wide.Dot(faceNormal, localCapsuleAxis, out var nDotAxis);
-            Vector3Wide.Dot(faceNormal, triangleCenterToCapsuleCenter, out var capsuleOffsetAlongNormal);
+            //capsuleOffsetAlongNormal = dot(localOffsetA - triangleCenter, faceNormal), and we've centered our working space on the triangle center.
+            Vector3Wide.Dot(faceNormal, localOffsetA, out var capsuleOffsetAlongNormal);
             //Note that capsuleOffsetAlongNormal may be negative when the capsule's center is on the non colliding side of the triangle.
             //That's fine- either the edge cases will produce better results, or no contacts will be generated at all.
             var faceDepth = a.HalfLength * Vector.Abs(nDotAxis) - capsuleOffsetAlongNormal;
 
-            TestEdge(b, localTriangleCenter, faceNormal, b.A, ab, localOffsetA, localCapsuleAxis, a.HalfLength,
+            TestEdge(triangle, faceNormal, triangle.A, ab, localOffsetA, localCapsuleAxis, a.HalfLength,
                 out var edgeDirection, out var ta, out var tb, out var bMin, out var bMax, out var edgeDepth, out var edgeNormal);
-            TestEdge(b, localTriangleCenter, faceNormal, b.A, ac, localOffsetA, localCapsuleAxis, a.HalfLength,
+            TestEdge(triangle, faceNormal, triangle.A, ac, localOffsetA, localCapsuleAxis, a.HalfLength,
                 out var edgeDirectionCandidate, out var taCandidate, out var tbCandidate, out var bMinCandidate, out var bMaxCandidate, out var edgeDepthCandidate, out var edgeNormalCandidate);
             var useAC = Vector.LessThan(edgeDepthCandidate, edgeDepth);
             Vector3Wide.ConditionalSelect(useAC, edgeDirectionCandidate, edgeDirection, out edgeDirection);
@@ -169,10 +175,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             edgeDepth = Vector.Min(edgeDepthCandidate, edgeDepth);
 
             Vector3Wide.Subtract(b.C, b.B, out var bc);
-            TestEdge(b, localTriangleCenter, faceNormal, b.B, bc, localOffsetA, localCapsuleAxis, a.HalfLength,
+            TestEdge(triangle, faceNormal, triangle.B, bc, localOffsetA, localCapsuleAxis, a.HalfLength,
                 out edgeDirectionCandidate, out taCandidate, out tbCandidate, out bMinCandidate, out bMaxCandidate, out edgeDepthCandidate, out edgeNormalCandidate);
             var useBC = Vector.LessThan(edgeDepthCandidate, edgeDepth);
-            Vector3Wide.ConditionalSelect(useBC, b.B, b.A, out var edgeStart);
+            Vector3Wide.ConditionalSelect(useBC, triangle.B, triangle.A, out var edgeStart);
             Vector3Wide.ConditionalSelect(useBC, edgeDirectionCandidate, edgeDirection, out edgeDirection);
             Vector3Wide.ConditionalSelect(useBC, edgeNormalCandidate, edgeNormal, out edgeNormal);
             ta = Vector.ConditionalSelect(useBC, taCandidate, ta);
@@ -185,18 +191,23 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             var useEdge = Vector.LessThan(edgeDepth, faceDepth);
             Vector3Wide.ConditionalSelect(useEdge, edgeNormal, faceNormal, out var localNormal);
             Vector3Wide.Dot(localNormal, faceNormal, out var localNormalDotFaceNormal);
-            if (Vector.EqualsAll(Vector.BitwiseOr(
-                    Vector.LessThanOrEqual(localNormalDotFaceNormal, Vector<float>.Zero),
-                    Vector.LessThan(depth + a.Radius, -speculativeMargin)), new Vector<int>(-1)))
+            var collidingWithSolidSide = Vector.GreaterThanOrEqual(localNormalDotFaceNormal, new Vector<float>(TriangleWide.BackfaceNormalDotRejectionThreshold));
+            var activeLanes = BundleIndexing.CreateMaskForCountInBundle(pairCount);
+            TriangleWide.ComputeNondegenerateTriangleMask(ab, ac, faceNormalLength, out _, out var nondegenerateMask);
+            var negativeMargin = -speculativeMargin;
+            var allowContacts = Vector.BitwiseAnd(Vector.BitwiseAnd(Vector.GreaterThanOrEqual(depth + a.Radius, negativeMargin), activeLanes), Vector.BitwiseAnd(collidingWithSolidSide, nondegenerateMask));
+            if (Vector.EqualsAll(allowContacts, Vector<int>.Zero))
             {
                 //All contact normals are on the back of the triangle or the distance is too large for the margin, so we can immediately quit.
                 manifold.Contact0Exists = Vector<int>.Zero;
                 manifold.Contact1Exists = Vector<int>.Zero;
                 return;
             }
-            Vector3Wide b0, b1;
+            Vector3Wide b0;
+            Vector3Wide b1;
             Vector<int> contactCount;
-            if (Vector.EqualsAny(useEdge, new Vector<int>(-1)))
+            useEdge = Vector.BitwiseAnd(useEdge, allowContacts);
+            if (Vector.LessThanAny(useEdge, Vector<int>.Zero))
             {
                 //At least one of the paths uses edges, so go ahead and create all edge contact related information.
                 //Borrowing from capsule-capsule again:
@@ -246,13 +257,13 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //The bounds check can share the clipping done for face contacts.
             //3) If an edge contact has generated two contacts, then no additional contacts are required.
 
-            if (Vector.LessThanOrEqualAny(contactCount, Vector<int>.One))
+            if (Vector.LessThanAny(Vector.BitwiseAnd(Vector.LessThanOrEqual(contactCount, Vector<int>.One), allowContacts), Vector<int>.Zero))
             {
-                ClipAgainstEdgePlane(b.A, ab, faceNormal, localOffsetA, localCapsuleAxis, out var abEntry, out var abExit);
-                ClipAgainstEdgePlane(b.B, bc, faceNormal, localOffsetA, localCapsuleAxis, out var bcEntry, out var bcExit);
+                ClipAgainstEdgePlane(triangle.A, ab, faceNormal, localOffsetA, localCapsuleAxis, out var abEntry, out var abExit);
+                ClipAgainstEdgePlane(triangle.B, bc, faceNormal, localOffsetA, localCapsuleAxis, out var bcEntry, out var bcExit);
                 //Winding matters. ab, bc, ca.
                 Vector3Wide.Negate(ac, out var ca);
-                ClipAgainstEdgePlane(b.A, ca, faceNormal, localOffsetA, localCapsuleAxis, out var caEntry, out var caExit);
+                ClipAgainstEdgePlane(triangle.A, ca, faceNormal, localOffsetA, localCapsuleAxis, out var caEntry, out var caExit);
                 var triangleIntervalMin = Vector.Max(abEntry, Vector.Max(bcEntry, caEntry));
                 var triangleIntervalMax = Vector.Min(abExit, Vector.Min(bcExit, caExit));
 
@@ -266,16 +277,15 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 overlapIntervalMax = Vector.Max(overlapIntervalMax, negativeHalfLength);
                 Vector3Wide.Scale(localCapsuleAxis, overlapIntervalMin, out var clippedOnA0);
                 Vector3Wide.Add(clippedOnA0, localOffsetA, out clippedOnA0);
-                Vector3Wide.Dot(clippedOnA0, faceNormal, out var nA0);
-                Vector3Wide.Dot(localTriangleCenter, faceNormal, out var trianglePlaneOffset);
-                var distanceAlongNormalA0 = nA0 - trianglePlaneOffset;
+                //distanceAlongNormalA0 = dot(a0, faceNormal) - dot(triangleCenter, faceNormal), and triangleCenter is zero since we're working locally to the triangle.
+                Vector3Wide.Dot(clippedOnA0, faceNormal, out var distanceAlongNormalA0);
                 Vector3Wide.Scale(faceNormal, distanceAlongNormalA0, out var toRemoveA0);
                 Vector3Wide.Subtract(clippedOnA0, toRemoveA0, out var faceCandidate0);
 
                 Vector3Wide.Scale(localCapsuleAxis, overlapIntervalMax, out var clippedOnA1);
                 Vector3Wide.Add(clippedOnA1, localOffsetA, out clippedOnA1);
-                Vector3Wide.Dot(clippedOnA1, faceNormal, out var nA1);
-                var distanceAlongNormalA1 = nA1 - trianglePlaneOffset;
+                //distanceAlongNormalA1 = dot(a1, faceNormal) - dot(triangleCenter, faceNormal), and triangleCenter is zero since we're working locally to the triangle.
+                Vector3Wide.Dot(clippedOnA1, faceNormal, out var distanceAlongNormalA1);
                 Vector3Wide.Scale(faceNormal, distanceAlongNormalA1, out var toRemoveA1);
                 Vector3Wide.Subtract(clippedOnA1, toRemoveA1, out var faceCandidate1);
 
@@ -308,44 +318,34 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 contactCount = Vector.ConditionalSelect(useCandidateForSecondContact, new Vector<int>(2), contactCount);
             }
 
-            //Measure the depths for the two contacts by seeing how far they are along the normal from the capsule.
-            //We'll do this by creating a plane positioned at the capsule center with a normal pointing against the contact normal.
-            //capsuleAxisPlaneNormal = (N x capsuleAxis) x capsuleAxis
-            //The depths are derived from testing a ray against that plane, starting from the contact position and going along the contact normal.
-            Vector3Wide.CrossWithoutOverlap(localNormal, localCapsuleAxis, out var nxa);
-            Vector3Wide.CrossWithoutOverlap(nxa, localCapsuleAxis, out var capsuleAxisPlaneNormal);
-            //If the resulting plane normal is near zero, then the capsule axis and face normal were roughly parallel.
-            //In that case, we can simply use the flipped face normal.
-            Vector3Wide.LengthSquared(capsuleAxisPlaneNormal, out var capsuleAxisPlaneNormalLengthSquared);
-            Vector3Wide.Negate(localNormal, out var negatedNormal);
-            Vector3Wide.ConditionalSelect(Vector.LessThan(capsuleAxisPlaneNormalLengthSquared, new Vector<float>(1e-10f)), negatedNormal, capsuleAxisPlaneNormal, out capsuleAxisPlaneNormal);
-            //Given that we have a special case that creates a plane normal that isn't perpendicular to the capsule axis, we need to pick a center point for the capsule plane
-            //which gives us the desired result- both contacts have the same depth matching the capsule endpoint closer to the triangle.
-            Vector3Wide.Dot(capsuleAxisPlaneNormal, localCapsuleAxis, out var capsuleAxisPlaneDot);
-            var planeAnchorOnCapsuleT = Vector.ConditionalSelect(Vector.LessThan(capsuleAxisPlaneDot, Vector<float>.Zero), -a.HalfLength, a.HalfLength);
-            Vector3Wide.Scale(localCapsuleAxis, planeAnchorOnCapsuleT, out var capsulePlaneAnchor);
-            Vector3Wide.Add(capsulePlaneAnchor, localOffsetA, out capsulePlaneAnchor);
+            //While we have computed a global depth, each contact has its own depth.
+            //Project the contact on B along the contact normal to the 'face' of A.
+            //A is a capsule, but we can treat it as having a faceNormalA = (localNormal x capsuleAxis) x capsuleAxis.
+            //The full computation is: 
+            //t = dot(contact + localOffsetB, faceNormalA) / dot(faceNormalA, localNormal)
+            //depth = dot(t * localNormal, localNormal) = t
+            Vector3Wide.CrossWithoutOverlap(localNormal, localCapsuleAxis, out var capsuleTangent);
+            Vector3Wide.CrossWithoutOverlap(capsuleTangent, localCapsuleAxis, out var faceNormalA);
+            Vector3Wide.Dot(faceNormalA, localNormal, out var faceNormalADotLocalNormal);
+            //Don't have to perform any calibration on the faceNormalA; it appears in both the numerator and denominator so the sign and magnitudes cancel.
+            var inverseFaceNormalADotLocalNormal = Vector<float>.One / faceNormalADotLocalNormal;
+            Vector3Wide.Add(localOffsetB, b0, out var offset0);
+            Vector3Wide.Add(localOffsetB, b1, out var offset1);
+            Vector3Wide.Dot(offset0, faceNormalA, out var t0);
+            Vector3Wide.Dot(offset1, faceNormalA, out var t1);
+            t0 *= inverseFaceNormalADotLocalNormal;
+            t1 *= inverseFaceNormalADotLocalNormal;
+            manifold.Depth0 = a.Radius + t0;
+            manifold.Depth1 = a.Radius + t1;
 
-            Vector3Wide.Subtract(capsulePlaneAnchor, b0, out var offset0);
-            Vector3Wide.Dot(capsuleAxisPlaneNormal, offset0, out var planeDistance0);
-            Vector3Wide.Subtract(capsulePlaneAnchor, b1, out var offset1);
-            Vector3Wide.Dot(capsuleAxisPlaneNormal, offset1, out var planeDistance1);
-            Vector3Wide.Dot(localNormal, capsuleAxisPlaneNormal, out var velocity);
-            var inverseVelocity = Vector<float>.One / velocity;
-            var separation0 = planeDistance0 * inverseVelocity;
-            var separation1 = planeDistance1 * inverseVelocity;
-            manifold.Depth0 = a.Radius - separation0;
-            manifold.Depth1 = a.Radius - separation1;
-            //While zero velocity should not occur mathematically, it is possible numerically.
-            //If it happens, we assume it's an extremely temporary state and just use a hack.
-            //(Zero velocity shouldn't happen because the local normal points toward the capsule axis, so the only way for the capsuleAxisPlane and the normal to be perpendicular
-            //is for the normal and capsuleAxis to be parallel, which is explicitly protected against earlier.)
-            Debug.Assert(Vector.EqualsAll(Vector.BitwiseOr(
-                Vector.GreaterThan(Vector.Abs(velocity), new Vector<float>(1e-15f)), 
-                Vector.OnesComplement(Vector.Equals(velocity, velocity))), new Vector<int>(-1)), "Velocity should be nonzero except in numerical corner cases.");
-            var useFallbackDepth = Vector.LessThan(Vector.Abs(velocity), new Vector<float>(1e-15f));
-            manifold.Depth0 = Vector.ConditionalSelect(useFallbackDepth, Vector<float>.Zero, manifold.Depth0);
-            manifold.Depth1 = Vector.ConditionalSelect(useFallbackDepth, Vector<float>.Zero, manifold.Depth1);
+            //If the 'velocity' above is very small, it means that the local normal and capsule axis are very nearly aligned and depths computed using it are likely numerically poor.
+            //In this situation, using more than one contact is pretty pointless anyway, so collapse the manifold to only one point and use the previously computed depth.
+            var collapse = Vector.LessThan(Vector.Abs(faceNormalADotLocalNormal), new Vector<float>(1e-7f));
+            manifold.Depth0 = Vector.ConditionalSelect(collapse, a.Radius + depth, manifold.Depth0);
+            //If the normal we found points away from the triangle normal, then it it's hitting the wrong side and should be ignored. (Note that we had an early out for this earlier.)
+            contactCount = Vector.ConditionalSelect(collidingWithSolidSide, contactCount, Vector<int>.Zero);
+            manifold.Contact0Exists = Vector.BitwiseAnd(allowContacts, Vector.BitwiseAnd(Vector.GreaterThan(contactCount, Vector<int>.Zero), Vector.GreaterThan(manifold.Depth0, negativeMargin)));
+            manifold.Contact1Exists = Vector.BitwiseAnd(allowContacts, Vector.BitwiseAnd(Vector.AndNot(Vector.Equals(contactCount, new Vector<int>(2)), collapse), Vector.GreaterThan(manifold.Depth1, negativeMargin)));
 
             //For feature ids, note that we have a few different potential sources of contacts. While we could go through and force each potential source to output ids,
             //there is a useful single unifying factor: where the contacts occur on the capsule axis. Using this, it doesn't matter if contacts are generated from face or edge cases,
@@ -354,37 +354,25 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //ta0 = ((b0 + N * depth0) - capsuleCenter) * capsuleAxis
             //ta1 = ((b1 + N * depth1) - capsuleCenter) * capsuleAxis
             //If ta0 > ta1, featureId0 = 1 and featureId1 = 0, otherwise featureId0 = 0 and featureId1 = 1.
-            //This does a little bit of redundant calculation, but it's much simpler to redo that work than to track everything we'd need from all potential contact sources.
-            Vector3Wide.Scale(localNormal, manifold.Depth0, out var toAOffset0);
-            Vector3Wide.Add(b0, toAOffset0, out var a0);
-            Vector3Wide.Subtract(a0, localOffsetA, out var capsuleToA0);
-            Vector3Wide.Dot(capsuleToA0, localCapsuleAxis, out var ta0);
-            Vector3Wide.Scale(localNormal, manifold.Depth1, out var toAOffset1);
-            Vector3Wide.Add(b1, toAOffset1, out var a1);
-            Vector3Wide.Subtract(a1, localOffsetA, out var capsuleToA1);
-            Vector3Wide.Dot(capsuleToA1, localCapsuleAxis, out var ta1);
+            //But note that all we really want is a degree of consistency, so pushing all the way back to the capsule axis isn't necessary.
+            //Instead, just compute the projection of the contacts along the capsule axis directly. This will tend to agree with the more in-depth formulation.
+            Vector3Wide.Subtract(b0, localOffsetA, out var localOffsetA0);
+            Vector3Wide.Subtract(b1, localOffsetA, out var localOffsetA1);
+            Vector3Wide.Dot(localOffsetA0, localCapsuleAxis, out var ta0);
+            Vector3Wide.Dot(localOffsetA1, localCapsuleAxis, out var ta1);
             var flipFeatureIds = Vector.LessThan(ta1, ta0);
             manifold.FeatureId0 = Vector.ConditionalSelect(flipFeatureIds, Vector<int>.One, Vector<int>.Zero);
             manifold.FeatureId1 = Vector.ConditionalSelect(flipFeatureIds, Vector<int>.Zero, Vector<int>.One);
 
             var faceFlag = Vector.ConditionalSelect(
-                Vector.GreaterThanOrEqual(localNormalDotFaceNormal, new Vector<float>(MeshReduction.MinimumDotForFaceCollision)), 
+                Vector.GreaterThanOrEqual(localNormalDotFaceNormal, new Vector<float>(MeshReduction.MinimumDotForFaceCollision)),
                 new Vector<int>(MeshReduction.FaceCollisionFlag), Vector<int>.Zero);
             manifold.FeatureId0 += faceFlag;
 
             //Transform contact positions into world space rotation, measured as offsets from the capsule (object A).
-            Matrix3x3Wide.TransformWithoutOverlap(b0, rB, out var contact0RelativeToB);
-            Vector3Wide.Add(contact0RelativeToB, offsetB, out manifold.OffsetA0);
-            Matrix3x3Wide.TransformWithoutOverlap(b1, rB, out var contact1RelativeToB);
-            Vector3Wide.Add(contact1RelativeToB, offsetB, out manifold.OffsetA1);
+            Matrix3x3Wide.TransformWithoutOverlap(localOffsetA0, rB, out manifold.OffsetA0);
+            Matrix3x3Wide.TransformWithoutOverlap(localOffsetA1, rB, out manifold.OffsetA1);
             Matrix3x3Wide.TransformWithoutOverlap(localNormal, rB, out manifold.Normal);
-
-            //If the normal we found points away from the triangle normal, then it it's hitting the wrong side and should be ignored. (Note that we had an early out for this earlier.)
-            contactCount = Vector.ConditionalSelect(Vector.GreaterThanOrEqual(localNormalDotFaceNormal, Vector<float>.Zero), contactCount, Vector<int>.Zero);
-            var depthThreshold = -speculativeMargin;
-            manifold.Contact0Exists = Vector.BitwiseAnd(Vector.GreaterThan(manifold.Depth0, depthThreshold), Vector.GreaterThan(contactCount, Vector<int>.Zero));
-            manifold.Contact1Exists = Vector.BitwiseAnd(Vector.GreaterThan(manifold.Depth1, depthThreshold), Vector.GreaterThan(contactCount, Vector<int>.One));
-
         }
 
 

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CompoundMeshContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CompoundMeshContinuations.cs
@@ -23,6 +23,8 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             collisionBatcher.Pool.Take(pairOverlaps.Length, out continuation.QueryBounds);
             continuation.RegionCount = pairOverlaps.Length;
             continuation.MeshOrientation = pair.OrientationB;
+            //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
+            continuation.Mesh = (Mesh*)pair.B;
             //A flip is required in mesh reduction whenever contacts are being generated as if the triangle is in slot B, which is whenever this pair has *not* been flipped.
             continuation.RequiresFlip = pair.FlipMask == 0;
 

--- a/BepuPhysics/CollisionDetection/CollisionTasks/ManifoldCandidateHelper.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/ManifoldCandidateHelper.cs
@@ -61,9 +61,29 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 {
                     var targetIndex = count[i];
                     ref var target = ref GetOffsetInstance(ref Unsafe.Add(ref candidates, targetIndex), i);
-                    //TODO: Check codegen. May be worth doing another offset instance for source data if the compiler inserts bounds checks.
+                    //TODO: Now that we're free of NS2.0, we could likely intrisify this to reduce some overhead. Still not very vectorization friendly.
                     GetFirst(ref target.X) = candidate.X[i];
                     GetFirst(ref target.Y) = candidate.Y[i];
+                    GetFirst(ref target.FeatureId) = candidate.FeatureId[i];
+                }
+            }
+            count = Vector.ConditionalSelect(newContactExists, count + Vector<int>.One, count);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AddCandidateWithDepth(ref ManifoldCandidate candidates, ref Vector<int> count, in ManifoldCandidate candidate, in Vector<int> newContactExists, int pairCount)
+        {
+            //Similar to above, but also takes the candidate's depth. Any user of this codepath is not going to rely on the reduction postpass to calculate depths.
+            for (int i = 0; i < pairCount; ++i)
+            {
+                if (newContactExists[i] < 0)
+                {
+                    var targetIndex = count[i];
+                    ref var target = ref GetOffsetInstance(ref Unsafe.Add(ref candidates, targetIndex), i);
+                    //TODO: Now that we're free of NS2.0, we could likely intrisify this to reduce some overhead. Still not very vectorization friendly.
+                    GetFirst(ref target.X) = candidate.X[i];
+                    GetFirst(ref target.Y) = candidate.Y[i];
+                    GetFirst(ref target.Depth) = candidate.Depth[i];
                     GetFirst(ref target.FeatureId) = candidate.FeatureId[i];
                 }
             }
@@ -85,15 +105,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             exists = Vector.BitwiseAnd(Vector.GreaterThan(candidate.Depth, minimumDepth), Vector.LessThan(new Vector<int>(i), rawContactCount));
         }
 
-        public static void Reduce(ref ManifoldCandidate candidates, in Vector<int> rawContactCount, int maxCandidateCount,
-            in Vector3Wide faceNormalA, in Vector3Wide normal, in Vector3Wide faceCenterBToFaceCenterA, in Vector3Wide tangentBX, in Vector3Wide tangentBY,
-            in Vector<float> epsilonScale, in Vector<float> minimumDepth, int pairCount,
-            out ManifoldCandidate contact0, out ManifoldCandidate contact1, out ManifoldCandidate contact2, out ManifoldCandidate contact3,
-            out Vector<int> contact0Exists, out Vector<int> contact1Exists, out Vector<int> contact2Exists, out Vector<int> contact3Exists)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SquishMaximumContactCount(Vector<int> rawContactCount, int pairCount, ref int maxCandidateCount, out Vector<int> maskedContactCount)
         {
             //See if we can avoid visiting some of the higher indices.
             //Mask out any contacts generated on the pairs which don't actually exist. They can waste time and cause problems.
-            Vector<int> maskedContactCount = rawContactCount;
+            maskedContactCount = rawContactCount;
             ref var maskedBase = ref Unsafe.As<Vector<int>, int>(ref maskedContactCount);
             for (int i = pairCount; i < Vector<int>.Count; ++i)
             {
@@ -107,15 +124,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                     break;
                 }
             }
-            if (maxCandidateCount == 0)
-            {
-                contact0Exists = Vector<int>.Zero;
-                contact1Exists = Vector<int>.Zero;
-                contact2Exists = Vector<int>.Zero;
-                contact3Exists = Vector<int>.Zero;
-                return;
-            }
-            //That's too many; four is plenty. We should choose how to get rid of the extra ones.
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void ComputeDepthsForReduction(ref int maxCandidateCount, in Vector3Wide faceNormalA, Vector<float> inverseFaceNormalADotNormal,
+            in Vector3Wide faceCenterBToFaceCenterA, in Vector3Wide tangentBX, in Vector3Wide tangentBY, Vector<float> minimumDepth, Vector<int> maskedContactCount, ref ManifoldCandidate candidates)
+        {
             //It's important to keep the deepest contact if there's any significant depth disparity, so we need to calculate depths before reduction.
             //Conceptually, we cast a ray from the point on face B toward the plane of face A along the contact normal:
             //depth = dot(pointOnFaceB - faceCenterA, faceNormalA) / dot(faceNormalA, normal)
@@ -123,9 +137,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //depth = dot(pointOnFaceB - faceCenterA, dotAxis)
             //depth = dot(faceCenterB + tangentBX * candidate.X + tangentBY * candidate.Y - faceCenterA, dotAxis)
             //depth = dot(faceCenterB - faceCenterA, dotAxis) + dot(tangentBX, dotAxis) * candidate.X + dot(tangentBY, dotAxis) * candidate.Y
-            Vector3Wide.Dot(faceNormalA, normal, out var axisScale);
-            axisScale = Vector<float>.One / axisScale;
-            Vector3Wide.Scale(faceNormalA, axisScale, out var dotAxis);
+            Vector3Wide.Scale(faceNormalA, inverseFaceNormalADotNormal, out var dotAxis);
             Vector3Wide.Dot(faceCenterBToFaceCenterA, dotAxis, out var negativeBaseDot);
             Vector3Wide.Dot(tangentBX, dotAxis, out var xDot);
             Vector3Wide.Dot(tangentBY, dotAxis, out var yDot);
@@ -135,6 +147,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 ref var candidate = ref Unsafe.Add(ref candidates, i);
                 candidate.Depth = candidate.X * xDot + candidate.Y * yDot - negativeBaseDot;
             }
+
             //See if we can compress the count any due to depth-rejected candidates.
             for (int i = maxCandidateCount - 1; i >= 0; --i)
             {
@@ -145,6 +158,22 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                     maxCandidateCount = i + 1;
                     break;
                 }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void InternalReduce(ref ManifoldCandidate candidates, int maxCandidateCount,
+            Vector<float> epsilonScale, Vector<float> minimumDepth, Vector<int> maskedContactCount,
+            out ManifoldCandidate contact0, out ManifoldCandidate contact1, out ManifoldCandidate contact2, out ManifoldCandidate contact3,
+            out Vector<int> contact0Exists, out Vector<int> contact1Exists, out Vector<int> contact2Exists, out Vector<int> contact3Exists)
+        {
+            if (maxCandidateCount == 0)
+            {
+                contact0Exists = Vector<int>.Zero;
+                contact1Exists = Vector<int>.Zero;
+                contact2Exists = Vector<int>.Zero;
+                contact3Exists = Vector<int>.Zero;
+                return;
             }
 
             //This early out breaks determinism. Early out and non-early out produce different results, and the choice of early out depends on the entire bundle.
@@ -245,6 +274,25 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             contact3Exists = Vector.GreaterThan(maxSignedArea * maxSignedArea, epsilon);
         }
 
+        public static void Reduce(ref ManifoldCandidate candidates, Vector<int> rawContactCount, int maxCandidateCount,
+            in Vector3Wide faceNormalA, Vector<float> inverseFaceNormalDotNormal, in Vector3Wide faceCenterBToFaceCenterA, in Vector3Wide tangentBX, in Vector3Wide tangentBY,
+            Vector<float> epsilonScale, Vector<float> minimumDepth, int pairCount,
+            out ManifoldCandidate contact0, out ManifoldCandidate contact1, out ManifoldCandidate contact2, out ManifoldCandidate contact3,
+            out Vector<int> contact0Exists, out Vector<int> contact1Exists, out Vector<int> contact2Exists, out Vector<int> contact3Exists)
+        {
+            SquishMaximumContactCount(rawContactCount, pairCount, ref maxCandidateCount, out var maskedContactCount);
+            ComputeDepthsForReduction(ref maxCandidateCount, faceNormalA, inverseFaceNormalDotNormal, faceCenterBToFaceCenterA, tangentBX, tangentBY, minimumDepth, maskedContactCount, ref candidates);
+            InternalReduce(ref candidates, maxCandidateCount, epsilonScale, minimumDepth, maskedContactCount, out contact0, out contact1, out contact2, out contact3, out contact0Exists, out contact1Exists, out contact2Exists, out contact3Exists);
+        }
+        public static void ReduceWithoutComputingDepths(ref ManifoldCandidate candidates, Vector<int> rawContactCount, int maxCandidateCount,
+            Vector<float> epsilonScale, Vector<float> minimumDepth, int pairCount,
+            out ManifoldCandidate contact0, out ManifoldCandidate contact1, out ManifoldCandidate contact2, out ManifoldCandidate contact3,
+            out Vector<int> contact0Exists, out Vector<int> contact1Exists, out Vector<int> contact2Exists, out Vector<int> contact3Exists)
+        {
+            SquishMaximumContactCount(rawContactCount, pairCount, ref maxCandidateCount, out var maskedContactCount);
+            InternalReduce(ref candidates, maxCandidateCount, epsilonScale, minimumDepth, maskedContactCount, out contact0, out contact1, out contact2, out contact3, out contact0Exists, out contact1Exists, out contact2Exists, out contact3Exists);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         unsafe static void PlaceCandidateInSlot(in ManifoldCandidateScalar candidate, int contactIndex,
             in Vector3 faceCenterB, in Vector3 faceBX, in Vector3 faceBY, float depth,
@@ -273,7 +321,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         public unsafe static void Reduce(ManifoldCandidateScalar* candidates, int candidateCount,
-            in Vector3 faceNormalA, in Vector3 localNormal, in Vector3 faceCenterA, in Vector3 faceCenterB, in Vector3 tangentBX, in Vector3 tangentBY,
+            in Vector3 faceNormalA, float inverseFaceNormalADotLocalNormal, in Vector3 faceCenterA, in Vector3 faceCenterB, in Vector3 tangentBX, in Vector3 tangentBY,
             float epsilonScale, float minimumDepth, in Matrix3x3 rotationToWorld, in Vector3 worldOffsetB, int slotIndex, ref Convex4ContactManifoldWide manifoldWide)
         {
             if (candidateCount == 0)
@@ -292,7 +340,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //depth = dot(pointOnFaceB - faceCenterA, dotAxis)
             //depth = dot(faceCenterB + tangentBX * candidate.X + tangentBY * candidate.Y - faceCenterA, dotAxis)
             //depth = dot(faceCenterB - faceCenterA, dotAxis) + dot(tangentBX, dotAxis) * candidate.X + dot(tangentBY, dotAxis) * candidate.Y
-            var dotAxis = faceNormalA / Vector3.Dot(faceNormalA, localNormal);
+            var dotAxis = faceNormalA * inverseFaceNormalADotLocalNormal;
             var faceCenterAToFaceCenterB = faceCenterB - faceCenterA;
             var baseDot = Vector3.Dot(faceCenterAToFaceCenterB, dotAxis);
             var xDot = Vector3.Dot(tangentBX, dotAxis);

--- a/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairContinuations.cs
@@ -29,6 +29,8 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             continuation.MeshOrientation = pair.OrientationB;
             //A flip is required in mesh reduction whenever contacts are being generated as if the triangle is in slot B, which is whenever this pair has *not* been flipped.
             continuation.RequiresFlip = pair.FlipMask == 0;
+            //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
+            continuation.Mesh = (Mesh*)pair.B;
 
             //All regions must be assigned ahead of time. Some trailing regions may be empty, so the dispatch may occur before all children are visited in the later loop.
             //That would result in potentially uninitialized values in region counts.

--- a/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairOverlapFinder.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairOverlapFinder.cs
@@ -37,8 +37,8 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                     pairsToTest[subpairIndex].Container = pair.B;
                 }
             }
-            
-            TriangleWide triangles = default;
+
+            TriangleWide triangles;
             nextSubpairIndex = 0;
             for (int i = 0; i < pairCount; ++i)
             {
@@ -72,7 +72,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                     Vector3Wide.Length(localOffsetA, out var radiusA);
                     BoundingBoxHelpers.ExpandLocalBoundingBoxes(ref min, ref max, radiusA, localOffsetA, localRelativeLinearVelocityA, angularVelocityA, angularVelocityB, dt,
                         maximumRadius, maximumAngularExpansion, maximumAllowedExpansion);
-                    
+
                     for (int innerIndex = 0; innerIndex < count; ++innerIndex)
                     {
                         ref var pairToTest = ref pairsToTest[nextSubpairIndex++];
@@ -80,7 +80,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                         Vector3Wide.ReadSlot(ref max, innerIndex, out pairToTest.Max);
                     }
                 }
-            }          
+            }
 
             //Doesn't matter what mesh/compound instance is used for the function; just using it as a source of the function.
             Debug.Assert(totalCompoundChildCount > 0);

--- a/BepuPhysics/CollisionDetection/CollisionTasks/SphereTriangleTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/SphereTriangleTester.cs
@@ -26,7 +26,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, 
+        public void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount,
             out Convex1ContactManifoldWide manifold)
         {
             //Work in the local space of the triangle, since it's quicker to transform the sphere position than the vertices of the triangle.
@@ -39,14 +39,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //localOffsetA = -localOffsetB, so pa = triangle.A + localOffsetB.
             Vector3Wide.Add(b.A, localOffsetB, out var pa);
             Vector3Wide.CrossWithoutOverlap(ab, ac, out var localTriangleNormal);
-            Vector3Wide.Dot(localTriangleNormal, pa, out var paN);
-            var collidingWithSolidSide = Vector.GreaterThan(paN, Vector<float>.Zero);
-            if (Vector.EqualsAll(collidingWithSolidSide, Vector<int>.Zero))
-            {
-                //No lanes can generate contacts due to the triangle's one sidedness.
-                manifold.ContactExists = Vector<int>.Zero;
-                return;
-            }
+            Vector3Wide.Length(localTriangleNormal, out var triangleNormalLength);
+            var inverseTriangleNormalLength = Vector<float>.One / triangleNormalLength;
+            Vector3Wide.Scale(localTriangleNormal, inverseTriangleNormalLength, out localTriangleNormal);
 
             //EdgeAB plane test: (pa x ab) * (ab x ac) >= 0
             //EdgeAC plane test: (ac x pa) * (ab x ac) >= 0
@@ -62,8 +57,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Vector3Wide.CrossWithoutOverlap(ac, pa, out var acxpa);
             Vector3Wide.Dot(paxab, localTriangleNormal, out var edgePlaneTestAB);
             Vector3Wide.Dot(acxpa, localTriangleNormal, out var edgePlaneTestAC);
-            Vector3Wide.Dot(localTriangleNormal, localTriangleNormal, out var triangleNormalLengthSquared);
-            var edgePlaneTestBC = triangleNormalLengthSquared - edgePlaneTestAB - edgePlaneTestAC;
+            var edgePlaneTestBC = Vector<float>.One - (edgePlaneTestAB + edgePlaneTestAC) * inverseTriangleNormalLength;
 
             var outsideAB = Vector.LessThan(edgePlaneTestAB, Vector<float>.Zero);
             var outsideAC = Vector.LessThan(edgePlaneTestAC, Vector<float>.Zero);
@@ -72,7 +66,8 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             var outsideAnyEdge = Vector.BitwiseOr(outsideAB, Vector.BitwiseOr(outsideAC, outsideBC));
             Vector3Wide localClosestOnTriangle;
             var negativeOne = new Vector<int>(-1);
-            if (Vector.EqualsAny(Vector.BitwiseAnd(collidingWithSolidSide, outsideAnyEdge), negativeOne))
+            var activeLanes = BundleIndexing.CreateMaskForCountInBundle(pairCount);
+            if (Vector.EqualsAny(Vector.BitwiseAnd(activeLanes, outsideAnyEdge), negativeOne))
             {
                 //At least one lane detected a point outside of the triangle. Choose one edge which is outside as the representative.
                 Vector3Wide.ConditionalSelect(outsideAC, ac, ab, out var edgeDirection);
@@ -91,11 +86,11 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 Vector3Wide.ConditionalSelect(outsideAnyEdge, pointOnEdge, localClosestOnTriangle, out localClosestOnTriangle);
 
             }
-            if (Vector.EqualsAny(Vector.AndNot(collidingWithSolidSide, outsideAnyEdge), negativeOne))
+            if (Vector.EqualsAny(Vector.AndNot(activeLanes, outsideAnyEdge), negativeOne))
             {
                 //p + N * (pa * N) / ||N||^2 = N * (pa * N) / ||N||^2 - (-p)
-                var nScale = paN / triangleNormalLengthSquared;
-                Vector3Wide.Scale(localTriangleNormal, nScale, out var offsetToPlane);
+                Vector3Wide.Dot(localTriangleNormal, pa, out var paN);
+                Vector3Wide.Scale(localTriangleNormal, paN, out var offsetToPlane);
                 Vector3Wide.Subtract(offsetToPlane, localOffsetB, out var pointOnFace);
 
                 Vector3Wide.ConditionalSelect(outsideAnyEdge, localClosestOnTriangle, pointOnFace, out localClosestOnTriangle);
@@ -113,10 +108,14 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifold.Depth = a.Radius - distance;
             //In the event that the sphere's center point is touching the triangle, the normal is undefined. In that case, the 'correct' normal would be the triangle's normal.
             //However, given that this is a pretty rare degenerate case and that we already treat triangle backfaces as noncolliding, we'll treat zero distance as a backface non-collision.
+            Vector3Wide.Dot(localTriangleNormal, manifold.Normal, out var faceNormalDotLocalNormal);
+            TriangleWide.ComputeNondegenerateTriangleMask(ab, ac, triangleNormalLength, out _, out var nondegenerateMask);
             manifold.ContactExists = Vector.BitwiseAnd(
-                Vector.GreaterThan(distance, Vector<float>.Zero),
                 Vector.BitwiseAnd(
-                    Vector.GreaterThanOrEqual(paN, Vector<float>.Zero),
+                    Vector.GreaterThan(distance, Vector<float>.Zero),
+                    nondegenerateMask),
+                Vector.BitwiseAnd(
+                    Vector.LessThanOrEqual(faceNormalDotLocalNormal, new Vector<float>(-TriangleWide.BackfaceNormalDotRejectionThreshold)),
                     Vector.GreaterThanOrEqual(manifold.Depth, -speculativeMargin)));
         }
 

--- a/BepuPhysics/CollisionDetection/CollisionTasks/TriangleCylinderTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/TriangleCylinderTester.cs
@@ -65,6 +65,40 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CreateEffectiveTriangleFaceNormal(in Vector3Wide triangleNormal, in Vector3Wide normal, Vector<float> faceNormalADotNormal, Vector<int> inactiveLanes,
+            out Vector3Wide effectiveFaceNormal, out Vector<float> inverseEffectiveFaceNormalDotNormal)
+        {
+            //NOTE: Triangle normal is expected by convention to be pointing in the direction of the backface.
+            //When the contact normal is nearly perpendicular to the triangle normal, computing per contact depths can become numerically impossible.
+            //To help with this case, we use an 'effective' triangle face normal for anything related to computing contact depths.
+            var absFaceNormalADotNormal = Vector.Abs(faceNormalADotNormal);
+            const float faceNormalFallbackThreshold = 1e-4f;
+            var needsFallbackFaceNormal = Vector.AndNot(Vector.LessThan(absFaceNormalADotNormal, new Vector<float>(faceNormalFallbackThreshold)), inactiveLanes);
+            if (Vector.EqualsAny(needsFallbackFaceNormal, new Vector<int>(-1)))
+            {
+                //Near-zero faceNormalADotNormal values only occur during edge or vertex collisions.
+                //During edge collisions, the local normal is perpendicular to the edge.
+                //We can safely push the triangle normal along the local normal to get an 'effective' normal that doesn't cause numerical catastrophe.
+                var pushScale = Vector.Max(Vector<float>.Zero, (absFaceNormalADotNormal - new Vector<float>(faceNormalFallbackThreshold)) / new Vector<float>(-faceNormalFallbackThreshold));
+                Vector3Wide.Scale(normal, pushScale * new Vector<float>(0.1f), out var effectiveFaceNormalPush);
+                Vector3Wide.Add(triangleNormal, effectiveFaceNormalPush, out effectiveFaceNormal);
+                //Length is guaranteed to be nonzero since this is only used when normal is near perpendicular.
+                Vector3Wide.Normalize(effectiveFaceNormal, out effectiveFaceNormal);
+                //Normalization could change things numerically, so we can't normalize any lanes that aren't supposed to be taking this code path.
+                Vector3Wide.ConditionalSelect(needsFallbackFaceNormal, effectiveFaceNormal, triangleNormal, out effectiveFaceNormal);
+            }
+            else
+            {
+                //No near-perpendicular contacts in this bundle.
+                effectiveFaceNormal = triangleNormal;
+
+            }
+            //Given the push above, this is guaranteed not to divide by zero.
+            Vector3Wide.Dot(effectiveFaceNormal, normal, out var effectiveFaceNormalDotNormal);
+            inverseEffectiveFaceNormalDotNormal = Vector<float>.One / effectiveFaceNormalDotNormal;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void Test(
             ref TriangleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
@@ -121,13 +155,13 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             var cylinderInsideTriangleEdgePlanes = Vector.BitwiseAnd(
                 Vector.LessThanOrEqual(abPlaneTest, Vector<float>.Zero),
                 Vector.BitwiseAnd(
-                    Vector.LessThanOrEqual(bcPlaneTest, Vector<float>.Zero), 
+                    Vector.LessThanOrEqual(bcPlaneTest, Vector<float>.Zero),
                     Vector.LessThanOrEqual(caPlaneTest, Vector<float>.Zero)));
             var cylinderInsideAndBelowTriangle = Vector.BitwiseAnd(cylinderInsideTriangleEdgePlanes, cylinderBelowPlane);
 
-            ManifoldCandidateHelper.CreateInactiveMask(pairCount, out var inactiveLanes);
-            var degenerate = Vector.LessThan(triangleNormalLength, new Vector<float>(1e-10f));
-            inactiveLanes = Vector.BitwiseOr(degenerate, inactiveLanes);
+            var inactiveLanes = BundleIndexing.CreateTrailingMaskForCountInBundle(pairCount);
+            TriangleWide.ComputeNondegenerateTriangleMask(triangleAB, triangleCA, triangleNormalLength, out var triangleEpsilonScale, out var nondegenerateMask);
+            inactiveLanes = Vector.BitwiseOr(Vector.OnesComplement(nondegenerateMask), inactiveLanes);
             inactiveLanes = Vector.BitwiseOr(cylinderInsideAndBelowTriangle, inactiveLanes);
             if (Vector.LessThanAll(inactiveLanes, Vector<int>.Zero))
             {
@@ -144,7 +178,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Vector3Wide.Subtract(cylinderSupportAlongNegatedTriangleNormal, localTriangleCenter, out var negatedTriangleNormalSupport);
             Vector3Wide.Dot(negatedTriangleNormalSupport, negatedTriangleNormal, out var triangleFaceDepth);
 
-            //Check if the extreme point on the hull is contained within the bounds of the triangle face. If it is, there is no need for a full depth refinement.
+            //Check if the extreme point on the cylinder is contained within the bounds of the triangle face. If it is, there is no need for a full depth refinement.
             Vector3Wide.Subtract(triangleA, cylinderSupportAlongNegatedTriangleNormal, out var closestToA);
             Vector3Wide.Subtract(triangleB, cylinderSupportAlongNegatedTriangleNormal, out var closestToB);
             Vector3Wide.Subtract(triangleC, cylinderSupportAlongNegatedTriangleNormal, out var closestToC);
@@ -183,7 +217,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 
             //If the cylinder is too far away or if it's on the backside of the triangle, don't generate any contacts.
             Vector3Wide.Dot(triangleNormal, localNormal, out var faceNormalADotNormal);
-            inactiveLanes = Vector.BitwiseOr(inactiveLanes, Vector.BitwiseOr(Vector.GreaterThanOrEqual(faceNormalADotNormal, Vector<float>.Zero), Vector.LessThan(depth, depthThreshold)));
+            inactiveLanes = Vector.BitwiseOr(inactiveLanes, Vector.BitwiseOr(Vector.GreaterThan(faceNormalADotNormal, new Vector<float>(-TriangleWide.BackfaceNormalDotRejectionThreshold)), Vector.LessThan(depth, depthThreshold)));
             if (Vector.LessThanAll(inactiveLanes, Vector<int>.Zero))
             {
                 //All lanes are either inactive or were found to have a depth lower than the speculative margin, so we can just quit early.
@@ -191,14 +225,18 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 return;
             }
 
-            //We generate contacts according to the dominant features along the collision normal.
-            //The possible pairs are:
-            //Face A-Cap A
-            //Face A-Side A
+            //Swap over to an edge case if the normal is not face aligned. For other shapes we tend to take the closest feature regardless, but here we're favoring the face a bit more by choosing a lower threshold.
+            var useTriangleEdgeCase = Vector.AndNot(Vector.LessThan(Vector.Abs(faceNormalADotNormal), new Vector<float>(0.2f)), inactiveLanes);
 
+            //We generate contacts according to the dominant features along the collision normal.
             var capCenterBY = Vector.ConditionalSelect(Vector.LessThan(localNormal.Y, Vector<float>.Zero), -b.HalfLength, b.HalfLength);
 
             var useCap = Vector.AndNot(Vector.GreaterThan(Vector.Abs(localNormal.Y), new Vector<float>(0.70710678118f)), inactiveLanes);
+
+            Vector3Wide localOffsetB0;
+            Vector3Wide localOffsetB1;
+            Vector3Wide localOffsetB2;
+            Vector3Wide localOffsetB3;
 
             if (Vector.LessThanAny(useCap, Vector<int>.Zero))
             {
@@ -227,51 +265,103 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 tMinCA = Vector.Min(Vector.Max(tMinCA, Vector<float>.Zero), Vector<float>.One);
                 tMaxCA = Vector.Min(Vector.Max(tMaxCA, Vector<float>.Zero), Vector<float>.One);
 
-                BoxCylinderTester.AddCandidateForEdge(pA, projectedAB, tMinAB, tMaxAB, intersectedAB, Vector<int>.Zero, useCap, pairCount, ref candidates, ref candidateCount);
-                BoxCylinderTester.AddCandidateForEdge(pB, projectedBC, tMinBC, tMaxBC, intersectedBC, Vector<int>.One, useCap, pairCount, ref candidates, ref candidateCount);
-                BoxCylinderTester.AddCandidateForEdge(pC, projectedCA, tMinCA, tMaxCA, intersectedCA, new Vector<int>(2), useCap, pairCount, ref candidates, ref candidateCount);
+                //While we projected onto the cylinder cap to do the triangle edge intersections, we use the triangle to create the contact manifold.
+                //There is no guaranteed projection from the cap to the triangle face since the normal can become perpendicular, but we can always measure from triangle to cylinder cap.
+                //Arbitrarily pick the triangle center as the origin of the tangent space, and AB as the x axis.
+                Vector3Wide.Length(triangleAB, out var triangleABLength);
+                Vector3Wide.Scale(triangleAB, Vector<float>.One / triangleABLength, out var triangleTangentX);
+                Vector3Wide.CrossWithoutOverlap(triangleTangentX, triangleNormal, out var triangleTangentY);
 
-                BoxCylinderTester.GenerateInteriorPoints(b, localNormal, closestOnB, out var interior0, out var interior1, out var interior2, out var interior3);
+                Vector2Wide tangentA, tangentB, tangentC;
+                Vector3Wide.Dot(triangle.A, triangleTangentX, out tangentA.X);
+                Vector3Wide.Dot(triangle.A, triangleTangentY, out tangentA.Y);
+                Vector3Wide.Dot(triangle.B, triangleTangentX, out tangentB.X);
+                Vector3Wide.Dot(triangle.B, triangleTangentY, out tangentB.Y);
+                Vector3Wide.Dot(triangle.C, triangleTangentX, out tangentC.X);
+                Vector3Wide.Dot(triangle.C, triangleTangentY, out tangentC.Y);
 
-                //Test the four points against the edge plane. Note that signs depend on the orientation of the cylinder.
-                TryAddInteriorPoint(interior0, new Vector<int>(8), pA, projectedAB, pB, projectedBC, pC, projectedCA, useCap, ref candidates, ref candidateCount, pairCount);
-                TryAddInteriorPoint(interior1, new Vector<int>(9), pA, projectedAB, pB, projectedBC, pC, projectedCA, useCap, ref candidates, ref candidateCount, pairCount);
-                TryAddInteriorPoint(interior2, new Vector<int>(10), pA, projectedAB, pB, projectedBC, pC, projectedCA, useCap, ref candidates, ref candidateCount, pairCount);
-                TryAddInteriorPoint(interior3, new Vector<int>(11), pA, projectedAB, pB, projectedBC, pC, projectedCA, useCap, ref candidates, ref candidateCount, pairCount);
+                Vector2Wide.Subtract(tangentB, tangentA, out var tangentAB);
+                Vector2Wide.Subtract(tangentC, tangentB, out var tangentBC);
+                Vector2Wide.Subtract(tangentA, tangentC, out var tangentCA);
 
-                Vector3Wide capCenterToTriangle;
-                capCenterToTriangle.X = triangleA.X;
-                capCenterToTriangle.Y = triangleA.Y - capCenterBY;
-                capCenterToTriangle.Z = triangleA.Z;
-                Vector3Wide tangentBX, tangentBY;
-                tangentBX.X = Vector<float>.One;
-                tangentBX.Y = Vector<float>.Zero;
-                tangentBX.Z = Vector<float>.Zero;
-                tangentBY.X = Vector<float>.Zero;
-                tangentBY.Y = Vector<float>.Zero;
-                tangentBY.Z = Vector<float>.One;
-                ManifoldCandidateHelper.Reduce(ref candidates, candidateCount, 10, triangleNormal, localNormal, capCenterToTriangle, tangentBX, tangentBY, epsilonScale, depthThreshold, pairCount,
+                BoxCylinderTester.AddCandidateForEdge(tangentA, tangentAB, tMinAB, tMaxAB, intersectedAB, Vector<int>.Zero, useCap, pairCount, ref candidates, ref candidateCount);
+                BoxCylinderTester.AddCandidateForEdge(tangentB, tangentBC, tMinBC, tMaxBC, intersectedBC, Vector<int>.One, useCap, pairCount, ref candidates, ref candidateCount);
+                BoxCylinderTester.AddCandidateForEdge(tangentC, tangentCA, tMinCA, tMaxCA, intersectedCA, new Vector<int>(2), useCap, pairCount, ref candidates, ref candidateCount);
+
+                var useCapTriangleFace = Vector.AndNot(useCap, useTriangleEdgeCase);
+                int maximumContactCountInBundle = 6;
+                if (Vector.LessThanAny(useCapTriangleFace, Vector<int>.Zero))
+                {
+                    //Project the points on the cylinder down to the triangle. Note that this is only valid if the normal is not perpendicular to the face normal.
+                    maximumContactCountInBundle = 10;
+                    BoxCylinderTester.GenerateInteriorPoints(b, localNormal, closestOnB, out var interiorOnCylinder0, out var interiorOnCylinder1, out var interiorOnCylinder2, out var interiorOnCylinder3);
+                    //pointOnTrianglePlane = pointOnCylinder + localNormal * t
+                    //y = sign(localNormal.Y) * b.HalfLength
+                    //pointOnCylinder = (interiorOnCylinderN.X, y, interiorOnCylinderN.Y)
+                    //t = dot(localTriangleCenter - pointOnCylinder, triangleNormal) / dot(triangleNormal, localNormal)
+                    var inverseDenominator = new Vector<float>(-1f) / faceNormalADotNormal;
+                    var yOffset = localTriangleCenter.Y - capCenterBY;
+                    var xOffset0 = localTriangleCenter.X - interiorOnCylinder0.X;
+                    var zOffset0 = localTriangleCenter.Z - interiorOnCylinder0.Y;
+                    var xOffset1 = localTriangleCenter.X - interiorOnCylinder1.X;
+                    var zOffset1 = localTriangleCenter.Z - interiorOnCylinder1.Y;
+                    var xOffset2 = localTriangleCenter.X - interiorOnCylinder2.X;
+                    var zOffset2 = localTriangleCenter.Z - interiorOnCylinder2.Y;
+                    var xOffset3 = localTriangleCenter.X - interiorOnCylinder3.X;
+                    var zOffset3 = localTriangleCenter.Z - interiorOnCylinder3.Y;
+                    var t0 = (xOffset0 * localNormal.X + yOffset * localNormal.Y + zOffset0 * localNormal.Z) * inverseDenominator;
+                    var t1 = (xOffset1 * localNormal.X + yOffset * localNormal.Y + zOffset1 * localNormal.Z) * inverseDenominator;
+                    var t2 = (xOffset2 * localNormal.X + yOffset * localNormal.Y + zOffset2 * localNormal.Z) * inverseDenominator;
+                    var t3 = (xOffset3 * localNormal.X + yOffset * localNormal.Y + zOffset3 * localNormal.Z) * inverseDenominator;
+                    //Projecting into the triangle's *tangent space* directly.
+                    //pointInTriangleTangentSpace = (dot(pointOnCylinder + localNormal * t, tangentX), dot(pointOnCylinder + localNormal * t, tangentY))
+                    Vector2Wide tangentLocalNormal;
+                    Vector3Wide.Dot(localNormal, triangleTangentX, out tangentLocalNormal.X);
+                    Vector3Wide.Dot(localNormal, triangleTangentY, out tangentLocalNormal.Y);
+                    Vector2Wide interior0, interior1, interior2, interior3;
+                    var yOnTangentX = yOffset * triangleTangentX.Y;
+                    var yOnTangentY = yOffset * triangleTangentY.Y;
+                    interior0.X = tangentLocalNormal.X * t0 - xOffset0 * triangleTangentX.X - yOnTangentX - zOffset0 * triangleTangentX.Z;
+                    interior0.Y = tangentLocalNormal.Y * t0 - xOffset0 * triangleTangentY.X - yOnTangentY - zOffset0 * triangleTangentY.Z;
+                    interior1.X = tangentLocalNormal.X * t1 - xOffset1 * triangleTangentX.X - yOnTangentX - zOffset1 * triangleTangentX.Z;
+                    interior1.Y = tangentLocalNormal.Y * t1 - xOffset1 * triangleTangentY.X - yOnTangentY - zOffset1 * triangleTangentY.Z;
+                    interior2.X = tangentLocalNormal.X * t2 - xOffset2 * triangleTangentX.X - yOnTangentX - zOffset2 * triangleTangentX.Z;
+                    interior2.Y = tangentLocalNormal.Y * t2 - xOffset2 * triangleTangentY.X - yOnTangentY - zOffset2 * triangleTangentY.Z;
+                    interior3.X = tangentLocalNormal.X * t3 - xOffset3 * triangleTangentX.X - yOnTangentX - zOffset3 * triangleTangentX.Z;
+                    interior3.Y = tangentLocalNormal.Y * t3 - xOffset3 * triangleTangentY.X - yOnTangentY - zOffset3 * triangleTangentY.Z;
+
+                    //Test the four points against the edge plane. Note that signs depend on the orientation of the cylinder.
+                    TryAddInteriorPoint(interior0, new Vector<int>(8), tangentA, tangentAB, tangentB, tangentBC, tangentC, tangentCA, useCapTriangleFace, ref candidates, ref candidateCount, pairCount);
+                    TryAddInteriorPoint(interior1, new Vector<int>(9), tangentA, tangentAB, tangentB, tangentBC, tangentC, tangentCA, useCapTriangleFace, ref candidates, ref candidateCount, pairCount);
+                    TryAddInteriorPoint(interior2, new Vector<int>(10), tangentA, tangentAB, tangentB, tangentBC, tangentC, tangentCA, useCapTriangleFace, ref candidates, ref candidateCount, pairCount);
+                    TryAddInteriorPoint(interior3, new Vector<int>(11), tangentA, tangentAB, tangentB, tangentBC, tangentC, tangentCA, useCapTriangleFace, ref candidates, ref candidateCount, pairCount);
+                }
+
+                Vector3Wide capNormal;
+                capNormal.X = Vector<float>.Zero;
+                capNormal.Y = Vector.ConditionalSelect(Vector.LessThan(localNormal.Y, Vector<float>.Zero), Vector<float>.One, new Vector<float>(-1));
+                capNormal.Z = Vector<float>.Zero;
+                Vector3Wide triangleCenterToCapCenter;
+                triangleCenterToCapCenter.X = -localTriangleCenter.X;
+                triangleCenterToCapCenter.Y = capCenterBY - localTriangleCenter.Y;
+                triangleCenterToCapCenter.Z = -localTriangleCenter.Z;
+                ManifoldCandidateHelper.Reduce(ref candidates, candidateCount, maximumContactCountInBundle, capNormal, -capNormal.Y / localNormal.Y, triangleCenterToCapCenter, triangleTangentX, triangleTangentY, epsilonScale, depthThreshold, pairCount,
                     out var candidate0, out var candidate1, out var candidate2, out var candidate3,
                     out manifold.Contact0Exists, out manifold.Contact1Exists, out manifold.Contact2Exists, out manifold.Contact3Exists);
 
-                Vector3Wide localContact;
-                localContact.X = candidate0.X;
-                localContact.Y = capCenterBY;
-                localContact.Z = candidate0.Y;
-                Vector3Wide.Add(localContact, localOffsetB, out var aToLocalContact);
-                Matrix3x3Wide.TransformWithoutOverlap(aToLocalContact, worldRB, out manifold.OffsetA0);
-                localContact.X = candidate1.X;
-                localContact.Z = candidate1.Y;
-                Vector3Wide.Add(localContact, localOffsetB, out aToLocalContact);
-                Matrix3x3Wide.TransformWithoutOverlap(aToLocalContact, worldRB, out manifold.OffsetA1);
-                localContact.X = candidate2.X;
-                localContact.Z = candidate2.Y;
-                Vector3Wide.Add(localContact, localOffsetB, out aToLocalContact);
-                Matrix3x3Wide.TransformWithoutOverlap(aToLocalContact, worldRB, out manifold.OffsetA2);
-                localContact.X = candidate3.X;
-                localContact.Z = candidate3.Y;
-                Vector3Wide.Add(localContact, localOffsetB, out aToLocalContact);
-                Matrix3x3Wide.TransformWithoutOverlap(aToLocalContact, worldRB, out manifold.OffsetA3);
+                localOffsetB0.X = triangleTangentX.X * candidate0.X + triangleTangentY.X * candidate0.Y + localTriangleCenter.X;
+                localOffsetB0.Y = triangleTangentX.Y * candidate0.X + triangleTangentY.Y * candidate0.Y + localTriangleCenter.Y;
+                localOffsetB0.Z = triangleTangentX.Z * candidate0.X + triangleTangentY.Z * candidate0.Y + localTriangleCenter.Z;
+                localOffsetB1.X = triangleTangentX.X * candidate1.X + triangleTangentY.X * candidate1.Y + localTriangleCenter.X;
+                localOffsetB1.Y = triangleTangentX.Y * candidate1.X + triangleTangentY.Y * candidate1.Y + localTriangleCenter.Y;
+                localOffsetB1.Z = triangleTangentX.Z * candidate1.X + triangleTangentY.Z * candidate1.Y + localTriangleCenter.Z;
+                localOffsetB2.X = triangleTangentX.X * candidate2.X + triangleTangentY.X * candidate2.Y + localTriangleCenter.X;
+                localOffsetB2.Y = triangleTangentX.Y * candidate2.X + triangleTangentY.Y * candidate2.Y + localTriangleCenter.Y;
+                localOffsetB2.Z = triangleTangentX.Z * candidate2.X + triangleTangentY.Z * candidate2.Y + localTriangleCenter.Z;
+                localOffsetB3.X = triangleTangentX.X * candidate3.X + triangleTangentY.X * candidate3.Y + localTriangleCenter.X;
+                localOffsetB3.Y = triangleTangentX.Y * candidate3.X + triangleTangentY.Y * candidate3.Y + localTriangleCenter.Y;
+                localOffsetB3.Z = triangleTangentX.Z * candidate3.X + triangleTangentY.Z * candidate3.Y + localTriangleCenter.Z;
+
                 manifold.FeatureId0 = candidate0.FeatureId;
                 manifold.FeatureId1 = candidate1.FeatureId;
                 manifold.FeatureId2 = candidate2.FeatureId;
@@ -292,123 +382,211 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             var useSide = Vector.AndNot(Vector.OnesComplement(useCap), inactiveLanes);
             if (Vector.LessThanAny(useSide, Vector<int>.Zero))
             {
-                //At least one lane needs a side-face manifold.
-                //Intersect the single edge of A with the edge planes of face A.
-                //Note that the edge planes are skewed to follow the local normal. Equivalent to projecting the side edge onto face A.
-                //Edge normals point inward.
-                Vector3Wide.CrossWithoutOverlap(localNormal, triangleAB, out var edgeNormalAB);
-                Vector3Wide.CrossWithoutOverlap(localNormal, triangleBC, out var edgeNormalBC);
-                Vector3Wide.CrossWithoutOverlap(localNormal, triangleCA, out var edgeNormalCA);
+                var useSideEdgeCase = Vector.BitwiseAnd(useSide, useTriangleEdgeCase);
+                Vector<float> depthTMin;
+                Vector<float> depthTMax;
+                Vector<float> cylinderTMin;
+                Vector<float> cylinderTMax;
 
-                //Center of the side line is just (closestOnB.X, 0, closestOnB.Z), sideLineDirection is just (0, 1, 0).
-                //t = dot(sideLineStart - pointOnFaceEdge, edgeNormal) / dot(sideLineDirection, edgeNormal)
-                var negativeOne = new Vector<float>(-1f);
-                //Guard against divisions by zero to avoid NaN infection.
-                var minValue = new Vector<float>(float.MinValue);
-                var maxValue = new Vector<float>(float.MaxValue);
-                var abDenominator = Vector.ConditionalSelect(Vector.Equals(edgeNormalAB.Y, Vector<float>.Zero), minValue, negativeOne / edgeNormalAB.Y);
-                var bcDenominator = Vector.ConditionalSelect(Vector.Equals(edgeNormalBC.Y, Vector<float>.Zero), minValue, negativeOne / edgeNormalBC.Y);
-                var caDenominator = Vector.ConditionalSelect(Vector.Equals(edgeNormalCA.Y, Vector<float>.Zero), minValue, negativeOne / edgeNormalCA.Y);
-                Vector3Wide.LengthSquared(edgeNormalAB, out var edgeNormalABLengthSquared);
-                Vector3Wide.LengthSquared(edgeNormalBC, out var edgeNormalBCLengthSquared);
-                Vector3Wide.LengthSquared(edgeNormalCA, out var edgeNormalCALengthSquared);
-                var inverseEdgeNormalABLengthSquared = Vector.ConditionalSelect(Vector.Equals(edgeNormalABLengthSquared, Vector<float>.Zero), maxValue, Vector<float>.One / edgeNormalABLengthSquared);
-                var inverseEdgeNormalBCLengthSquared = Vector.ConditionalSelect(Vector.Equals(edgeNormalBCLengthSquared, Vector<float>.Zero), maxValue, Vector<float>.One / edgeNormalBCLengthSquared);
-                var inverseEdgeNormalCALengthSquared = Vector.ConditionalSelect(Vector.Equals(edgeNormalCALengthSquared, Vector<float>.Zero), maxValue, Vector<float>.One / edgeNormalCALengthSquared);
-                Vector3Wide aToSideLine, bToSideLine, cToSideLine;
-                aToSideLine.X = closestOnB.X - triangleA.X;
-                aToSideLine.Y = -triangleA.Y;
-                aToSideLine.Z = closestOnB.Z - triangleA.Z;
-                bToSideLine.X = closestOnB.X - triangleB.X;
-                bToSideLine.Y = -triangleB.Y;
-                bToSideLine.Z = closestOnB.Z - triangleB.Z;
-                cToSideLine.X = closestOnB.X - triangleC.X;
-                cToSideLine.Y = -triangleC.Y;
-                cToSideLine.Z = closestOnB.Z - triangleC.Z;
+                //At least one lane is going to use the side edge case.
+                //Identify the dominant edge based on alignment with the local normal.
+                Vector3Wide.Dot(edgePlaneAB, localNormal, out var abEdgeAlignment);
+                Vector3Wide.Dot(edgePlaneBC, localNormal, out var bcEdgeAlignment);
+                Vector3Wide.Dot(edgePlaneCA, localNormal, out var caEdgeAlignment);
 
-                Vector3Wide.Dot(edgeNormalAB, aToSideLine, out var abNumerator);
-                Vector3Wide.Dot(edgeNormalBC, bToSideLine, out var bcNumerator);
-                Vector3Wide.Dot(edgeNormalCA, cToSideLine, out var caNumerator);
-                var tAB = abNumerator * abDenominator;
-                var tBC = bcNumerator * bcDenominator;
-                var tCA = caNumerator * caDenominator;
-                //As the side aligns with one of the edge directions, unrestrict that axis to avoid numerical noise.
-                //Do something similar to capsule tests: 
-                //sin(angleFromEdgePlane) = dot(sideLineDirection, edgeNormal / ||edgeNormal||) / ||sideLineDirection||
-                //sin(angleFromEdgePlane) = dot(sideLineDirection, edgeNormal / ||edgeNormal||)
-                //Only relevant in very small angles, so sin(x) ~= x:
-                //angleFromEdgePlane = dot(sideLineDirection, edgeNormal / ||edgeNormal||)
-                //Interpolation behavior is pretty arbitrary, so squaring is fine:
-                //angleFromEdgePlane^2 = dot(sideLineDirection, edgeNormal)^2 / ||edgeNormal||^2
-                const float lowerThresholdAngle = 0.01f;
-                const float upperThresholdAngle = 0.02f;
-                const float lowerThreshold = lowerThresholdAngle * lowerThresholdAngle;
-                const float upperThreshold = upperThresholdAngle * upperThresholdAngle;
-                var interpolationMin = new Vector<float>(upperThreshold);
-                var inverseInterpolationSpan = new Vector<float>(1f / (upperThreshold - lowerThreshold));
-                var unrestrictWeightAB = Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, (interpolationMin - edgeNormalAB.Y * edgeNormalAB.Y * inverseEdgeNormalABLengthSquared) * inverseInterpolationSpan));
-                var unrestrictWeightBC = Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, (interpolationMin - edgeNormalBC.Y * edgeNormalBC.Y * inverseEdgeNormalBCLengthSquared) * inverseInterpolationSpan));
-                var unrestrictWeightCA = Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, (interpolationMin - edgeNormalCA.Y * edgeNormalCA.Y * inverseEdgeNormalCALengthSquared) * inverseInterpolationSpan));
-                var regularWeightAB = Vector<float>.One - unrestrictWeightAB;
-                var regularWeightBC = Vector<float>.One - unrestrictWeightBC;
-                var regularWeightCA = Vector<float>.One - unrestrictWeightCA;
-                var negativeHalfLength = -b.HalfLength;
+                var max = Vector.Max(abEdgeAlignment, Vector.Max(bcEdgeAlignment, caEdgeAlignment));
+                var abIsDominant = Vector.Equals(max, abEdgeAlignment);
+                var bcIsDominant = Vector.Equals(max, bcEdgeAlignment);
 
-                var enteringAB = Vector.GreaterThan(edgeNormalAB.Y, Vector<float>.Zero);
-                var enteringBC = Vector.GreaterThan(edgeNormalBC.Y, Vector<float>.Zero);
-                var enteringCA = Vector.GreaterThan(edgeNormalCA.Y, Vector<float>.Zero);
-                var weightedAB = regularWeightAB * tAB;
-                var weightedBC = regularWeightBC * tBC;
-                var weightedCA = regularWeightCA * tCA;
-                var tABEntry = Vector.ConditionalSelect(enteringAB, unrestrictWeightAB * negativeHalfLength + weightedAB, minValue);
-                var tABExit = Vector.ConditionalSelect(enteringAB, maxValue, unrestrictWeightAB * b.HalfLength + weightedAB);
-                var tBCEntry = Vector.ConditionalSelect(enteringBC, unrestrictWeightBC * negativeHalfLength + weightedBC, minValue);
-                var tBCExit = Vector.ConditionalSelect(enteringBC, maxValue, unrestrictWeightBC * b.HalfLength + weightedBC);
-                var tCAEntry = Vector.ConditionalSelect(enteringCA, unrestrictWeightCA * negativeHalfLength + weightedCA, minValue);
-                var tCAExit = Vector.ConditionalSelect(enteringCA, maxValue, unrestrictWeightCA * b.HalfLength + weightedCA);
-                var tMax = Vector.Min(b.HalfLength, Vector.Max(-b.HalfLength, Vector.Min(tABExit, Vector.Min(tBCExit, tCAExit))));
-                var tMin = Vector.Min(b.HalfLength, Vector.Max(-b.HalfLength, Vector.Max(tABEntry, Vector.Max(tBCEntry, tCAEntry))));
+                Vector3Wide.ConditionalSelect(abIsDominant, triangleA, triangleC, out var dominantEdgeStart);
+                Vector3Wide.ConditionalSelect(bcIsDominant, triangleB, dominantEdgeStart, out dominantEdgeStart);
+                Vector3Wide.ConditionalSelect(abIsDominant, triangleAB, triangleCA, out var dominantEdgeOffset);
+                Vector3Wide.ConditionalSelect(bcIsDominant, triangleBC, dominantEdgeOffset, out dominantEdgeOffset);
 
-                var inverseFaceNormalDotLocalNormal = Vector<float>.One / faceNormalADotNormal;
-                Vector3Wide localContact0, localContact1;
-                localContact0.X = localContact1.X = closestOnB.X;
-                localContact0.Y = tMin;
-                localContact1.Y = tMax;
-                localContact0.Z = localContact1.Z = closestOnB.Z;
-                Matrix3x3Wide.TransformWithoutOverlap(localContact0, worldRB, out var contact0);
-                Matrix3x3Wide.TransformWithoutOverlap(localContact1, worldRB, out var contact1);
-                Vector3Wide.Add(contact0, offsetB, out contact0);
-                Vector3Wide.Add(contact1, offsetB, out contact1);
-                Vector3Wide.ConditionalSelect(useSide, contact0, manifold.OffsetA0, out manifold.OffsetA0);
-                Vector3Wide.ConditionalSelect(useSide, contact1, manifold.OffsetA1, out manifold.OffsetA1);
+                //If the contacts are near an edge and the cylinder side is aligned with that edge, it can lead to numerical blippyblips in contact positions.
+                //In this case, expand the contact interval for the parallel edge (so either the cylinder side endpoints or the other triangle edges will bound the interval).
+                //sin(angle between triangle edge direction and cylinder edge direction) = dot(dominantEdgeOffset, (-localNormal.Z, 0, localNormal.X)) / (||dominantEdgeOffset|| * ||(-localNormal.Z, 0, localNormal.X)||)
+                //sinAngle * (||dominantEdgeOffset|| * ||(-localNormal.Z, 0, localNormal.X)||) = dot(dominantEdgeOffset, (-localNormal.Z, 0, localNormal.X))
+                //Not concerned about sign; either way works, and we don't really care about perfectly linear interpolation... so square it.
+                //sinAngle^2 * ||dominantEdgeOffset||^2 * ||(-localNormal.Z, 0, localNormal.X)||^2 = dot(dominantEdgeOffset, (-localNormal.Z, 0, localNormal.X))^2         
+                const float lowerSinAngleThreshold = 0.01f;
+                const float upperSinAngleThreshold = 0.02f;
+                var dominantEdgeDotHorizontalNormal = dominantEdgeOffset.Z * localNormal.X - dominantEdgeOffset.X * localNormal.Z;
+                var dominantEdgeDotHorizontalNormalSquared = dominantEdgeDotHorizontalNormal * dominantEdgeDotHorizontalNormal;
+                Vector3Wide.LengthSquared(dominantEdgeOffset, out var dominantEdgeLengthSquared);
+                var horizontalNormalLengthSquared = localNormal.X * localNormal.X + localNormal.Z * localNormal.Z;
+                var interpolationScale = dominantEdgeLengthSquared * horizontalNormalLengthSquared;
+                var interpolationMin = new Vector<float>(lowerSinAngleThreshold * lowerSinAngleThreshold);
+                var inverseInterpolationSpan = new Vector<float>(1f / (upperSinAngleThreshold * upperSinAngleThreshold - lowerSinAngleThreshold * lowerSinAngleThreshold));
+                var restrictWeight = Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, (dominantEdgeDotHorizontalNormalSquared / interpolationScale - interpolationMin) * inverseInterpolationSpan));
+
+                //Either triangle edge-cylinder side, or triangle face-cylinder side.
+                if (Vector.LessThanAny(useSideEdgeCase, Vector<int>.Zero))
+                {
+                    //At least one lane is edge-side. This is relatively simple; we need only test the dominant edge of the triangle with the side of the cylinder.
+                    //If the triangle edge and cylinder edge are close to parallel, expand the intersection interval so we can generate more than one contact.
+                    //For the single contact case, all we need is to test the triangle edge versus the plane formed by the cylinder side edge and the local normal.
+                    //(0,1,0) x localNormal = (-localNormal.Z, 0, localNormal.X)
+                    var cylinderEdgeToDominantEdgeStartX = dominantEdgeStart.X - closestOnB.X;
+                    var cylinderEdgeToDominantEdgeStartZ = dominantEdgeStart.Z - closestOnB.Z;
+                    var numerator = cylinderEdgeToDominantEdgeStartX * localNormal.Z - cylinderEdgeToDominantEdgeStartZ * localNormal.X;
+                    var edgeT = numerator / dominantEdgeDotHorizontalNormal;
+
+                    //As the unrestrict weight increases, expand the interval on the triangle edge until it covers the entire cylinder edge.
+                    //Past the upper bound, we no longer consider the single contact edgeT, since it will be approaching a singularity.
+                    //tCenter = dot(cylinderSideEdgeCenter - dominantEdgeStart, dominantEdgeOffset / ||dominantEdgeOffset||^2)
+                    //tMax = tCenter + cylinder.HalfLength * dominantEdgeOffset.Y / ||dominantEdgeOffset||^2
+                    var inverseEdgeOffsetLengthSquared = Vector<float>.One / dominantEdgeLengthSquared;
+                    var tCenter = -(cylinderEdgeToDominantEdgeStartX * dominantEdgeOffset.X + dominantEdgeStart.Y * dominantEdgeOffset.Y + cylinderEdgeToDominantEdgeStartZ * dominantEdgeOffset.Z) * inverseEdgeOffsetLengthSquared;
+                    var projectedExtentOffset = b.HalfLength * Vector.Abs(dominantEdgeOffset.Y) * inverseEdgeOffsetLengthSquared;
+                    cylinderTMin = tCenter - projectedExtentOffset;
+                    cylinderTMax = tCenter + projectedExtentOffset;
+                    //Note that the edgeT value is ignored once the denominator is small enough. Avoids division by zero propagation.
+                    var regularContribution = restrictWeight * Vector.ConditionalSelect(Vector.LessThan(dominantEdgeDotHorizontalNormalSquared, interpolationMin), tCenter, edgeT);
+                    var unrestrictWeight = Vector<float>.One - restrictWeight;
+                    cylinderTMin = regularContribution + unrestrictWeight * cylinderTMin;
+                    cylinderTMax = regularContribution + unrestrictWeight * cylinderTMax;
+
+                    cylinderTMin = Vector.Min(Vector.Max(Vector<float>.Zero, cylinderTMin), Vector<float>.One);
+                    cylinderTMax = Vector.Min(Vector.Max(Vector<float>.Zero, cylinderTMax), Vector<float>.One);
+
+                    //Compute depth by projecting back to the cylinder plane. 
+                    //Its normal is the horizontal local normal.
+                    //depth = dot(dominantEdgeStart + dominantEdgeOffset * t - cylinderEdgeCenter, horizontalLocalNormal) / dot(horizontalLocalNormal, localNormal)
+                    //dot(horizontalLocalNormal, localNormal) == localNormal.X^2 + localNormal.Z^2
+                    //depth = (dot(dominantEdgeStart - cylinderEdgeCenter, horizontalLocalNormal) + t * (dominantEdgeOffset, horizontalLocalNormal)) / (localNormal.X^2 + localNormal.Z^2)
+                    var inverseDepthDenominator = new Vector<float>(-1f) / horizontalNormalLengthSquared;
+                    var depthBase = (cylinderEdgeToDominantEdgeStartX * localNormal.X + cylinderEdgeToDominantEdgeStartZ * localNormal.Z) * inverseDepthDenominator;
+                    var tDepthScale = (dominantEdgeOffset.X * localNormal.X + dominantEdgeOffset.Z * localNormal.Z) * inverseDepthDenominator;
+                    depthTMin = depthBase + tDepthScale * cylinderTMin;
+                    depthTMax = depthBase + tDepthScale * cylinderTMax;
+
+                    Vector3Wide.Scale(dominantEdgeOffset, cylinderTMin, out var minOffset);
+                    Vector3Wide.Scale(dominantEdgeOffset, cylinderTMax, out var maxOffset);
+                    localOffsetB0.X = Vector.ConditionalSelect(useSideEdgeCase, dominantEdgeStart.X + minOffset.X, localOffsetB0.X);
+                    localOffsetB0.Y = Vector.ConditionalSelect(useSideEdgeCase, dominantEdgeStart.Y + minOffset.Y, localOffsetB0.Y);
+                    localOffsetB0.Z = Vector.ConditionalSelect(useSideEdgeCase, dominantEdgeStart.Z + minOffset.Z, localOffsetB0.Z);
+                    localOffsetB1.X = Vector.ConditionalSelect(useSideEdgeCase, dominantEdgeStart.X + maxOffset.X, localOffsetB1.X);
+                    localOffsetB1.Y = Vector.ConditionalSelect(useSideEdgeCase, dominantEdgeStart.Y + maxOffset.Y, localOffsetB1.Y);
+                    localOffsetB1.Z = Vector.ConditionalSelect(useSideEdgeCase, dominantEdgeStart.Z + maxOffset.Z, localOffsetB1.Z);
+
+                }
+                var useSideTriangleFace = Vector.AndNot(useSide, useTriangleEdgeCase);
+                if (Vector.LessThanAny(useSideTriangleFace, Vector<int>.Zero))
+                {
+                    //Project the cylinder edge down onto the triangle plane. We know it's numerically valid because useTriangleEdgeCase is false for this lane.
+                    //tCenterToTriangleSurface = dot(localTriangleCenter - (closestOnB.X, 0, closestOnB.Z), triangleNormal) / dot(localNormal, triangleNormal)
+                    //Note that we *could* use the computed depth for the closest point here, but that would allow some numerical error to compound and it only saves us a single dot product.
+                    var inverseDenominator = Vector<float>.One / faceNormalADotNormal;
+                    var xzContribution = (localTriangleCenter.X - closestOnB.X) * triangleNormal.X + (localTriangleCenter.Z - closestOnB.Z) * triangleNormal.Z;
+                    var tMinToTriangle = (xzContribution + (localTriangleCenter.Y + b.HalfLength) * triangleNormal.Y) * inverseDenominator;
+                    var tMaxToTriangle = (xzContribution + (localTriangleCenter.Y - b.HalfLength) * triangleNormal.Y) * inverseDenominator;
+                    Vector3Wide minOnTriangle, maxOnTriangle;
+                    minOnTriangle.X = tMinToTriangle * localNormal.X + closestOnB.X;
+                    minOnTriangle.Y = tMinToTriangle * localNormal.Y - b.HalfLength;
+                    minOnTriangle.Z = tMinToTriangle * localNormal.Z + closestOnB.Z;
+                    maxOnTriangle.X = tMaxToTriangle * localNormal.X + closestOnB.X;
+                    maxOnTriangle.Y = tMaxToTriangle * localNormal.Y + b.HalfLength;
+                    maxOnTriangle.Z = tMaxToTriangle * localNormal.Z + closestOnB.Z;
+                    Vector3Wide.Subtract(maxOnTriangle, minOnTriangle, out var minToMax);
+                    //We now have points on the surface of the triangle. Use them as a ray to intersect the triangle's edge planes.
+                    var numeratorAB = (triangleA.X - minOnTriangle.X) * edgePlaneAB.X + (triangleA.Y - minOnTriangle.Y) * edgePlaneAB.Y + (triangleA.Z - minOnTriangle.Z) * edgePlaneAB.Z;
+                    var numeratorBC = (triangleB.X - minOnTriangle.X) * edgePlaneBC.X + (triangleB.Y - minOnTriangle.Y) * edgePlaneBC.Y + (triangleB.Z - minOnTriangle.Z) * edgePlaneBC.Z;
+                    var numeratorCA = (triangleC.X - minOnTriangle.X) * edgePlaneCA.X + (triangleC.Y - minOnTriangle.Y) * edgePlaneCA.Y + (triangleC.Z - minOnTriangle.Z) * edgePlaneCA.Z;
+                    var denominatorAB = minToMax.X * edgePlaneAB.X + minToMax.Y * edgePlaneAB.Y + minToMax.Z * edgePlaneAB.Z;
+                    var denominatorBC = minToMax.X * edgePlaneBC.X + minToMax.Y * edgePlaneBC.Y + minToMax.Z * edgePlaneBC.Z;
+                    var denominatorCA = minToMax.X * edgePlaneCA.X + minToMax.Y * edgePlaneCA.Y + minToMax.Z * edgePlaneCA.Z;
+                    //Protect against division by zero. This preserves sign and allows values to go to relatively enormous values.
+                    var threshold = new Vector<float>(1e-30f);
+                    var negativeThreshold = -threshold;
+                    //A ray is 'exiting' if the ray's direction is aligned with the edge normal, exiting otherwise.
+                    var exitingAB = Vector.LessThanOrEqual(denominatorAB, Vector<float>.Zero);
+                    var exitingBC = Vector.LessThanOrEqual(denominatorBC, Vector<float>.Zero);
+                    var exitingCA = Vector.LessThanOrEqual(denominatorCA, Vector<float>.Zero);
+                    denominatorAB = Vector.ConditionalSelect(Vector.LessThan(Vector.Abs(denominatorAB), threshold), Vector.ConditionalSelect(exitingAB, negativeThreshold, threshold), denominatorAB);
+                    denominatorBC = Vector.ConditionalSelect(Vector.LessThan(Vector.Abs(denominatorBC), threshold), Vector.ConditionalSelect(exitingBC, negativeThreshold, threshold), denominatorBC);
+                    denominatorCA = Vector.ConditionalSelect(Vector.LessThan(Vector.Abs(denominatorCA), threshold), Vector.ConditionalSelect(exitingCA, negativeThreshold, threshold), denominatorCA);
+                    var edgeTAB = numeratorAB / denominatorAB;
+                    var edgeTBC = numeratorBC / denominatorBC;
+                    var edgeTCA = numeratorCA / denominatorCA;
+
+                    //Take the first exit and last entry to create the interval of intersection.
+                    var minValue = new Vector<float>(float.MinValue);
+                    var maxValue = new Vector<float>(float.MaxValue);
+                    var entryAB = Vector.ConditionalSelect(exitingAB, minValue, edgeTAB);
+                    var entryBC = Vector.ConditionalSelect(exitingBC, minValue, edgeTBC);
+                    var entryCA = Vector.ConditionalSelect(exitingCA, minValue, edgeTCA);
+                    var exitAB = Vector.ConditionalSelect(exitingAB, edgeTAB, maxValue);
+                    var exitBC = Vector.ConditionalSelect(exitingBC, edgeTBC, maxValue);
+                    var exitCA = Vector.ConditionalSelect(exitingCA, edgeTCA, maxValue);
+
+                    //If the dominant edge is parallel with the cylinder side edge, then unrestrict the interval.
+                    //Entry T values are unrestricted to 0, exit T values are unrestricted to 1.
+                    var caIsDominant = Vector.AndNot(Vector.OnesComplement(abIsDominant), bcIsDominant);
+                    entryAB = Vector.ConditionalSelect(abIsDominant, entryAB * restrictWeight, entryAB);
+                    entryBC = Vector.ConditionalSelect(bcIsDominant, entryBC * restrictWeight, entryBC);
+                    entryCA = Vector.ConditionalSelect(caIsDominant, entryCA * restrictWeight, entryCA);
+                    var unrestrictWeight = Vector<float>.One - restrictWeight;
+                    exitAB = Vector.ConditionalSelect(abIsDominant, exitAB * restrictWeight + unrestrictWeight, exitAB);
+                    exitBC = Vector.ConditionalSelect(bcIsDominant, exitBC * restrictWeight + unrestrictWeight, exitBC);
+                    exitCA = Vector.ConditionalSelect(caIsDominant, exitCA * restrictWeight + unrestrictWeight, exitCA);
+
+                    var sideTriangleCylinderTMin = Vector.Max(entryAB, Vector.Max(entryBC, entryCA));
+                    var sideTriangleCylinderTMax = Vector.Min(exitAB, Vector.Min(exitBC, exitCA));
+
+                    //Note that the local normal should have been created such that projecting the cylinder edge down along it *should * result in an intersection with the triangle.
+                    //That would mean exitT >= entryT.However, due to numerical error, that is not strictly guaranteed.
+                    //This will typically happen in a vertex case.
+                    //We can choose the vertex in these cases by examining which edges contributed the intersections forming the bounds of the interval.
+                    var useVertexFallback = Vector.BitwiseAnd(Vector.LessThan(sideTriangleCylinderTMax, sideTriangleCylinderTMin), useSideTriangleFace);
+                    var abContributedBound = Vector.BitwiseOr(Vector.Equals(edgeTAB, sideTriangleCylinderTMin), Vector.Equals(edgeTAB, sideTriangleCylinderTMax));
+                    var bcContributedBound = Vector.BitwiseOr(Vector.Equals(edgeTBC, sideTriangleCylinderTMin), Vector.Equals(edgeTBC, sideTriangleCylinderTMax));
+                    var caContributedBound = Vector.BitwiseOr(Vector.Equals(edgeTCA, sideTriangleCylinderTMin), Vector.Equals(edgeTCA, sideTriangleCylinderTMax));
+                    var useA = Vector.BitwiseAnd(caContributedBound, abContributedBound);
+                    var useB = Vector.BitwiseAnd(abContributedBound, bcContributedBound);
+                    //var useC = Vector.BitwiseAnd(bcContributedBound, caContributedBound);
+                    Vector3Wide.ConditionalSelect(useA, triangleA, triangleC, out var vertexFallback);
+                    Vector3Wide.ConditionalSelect(useB, triangleB, vertexFallback, out vertexFallback);
+
+                    //Bound the interval to the cylinder's extent.
+                    cylinderTMin = Vector.ConditionalSelect(useSideTriangleFace, Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, sideTriangleCylinderTMin)), cylinderTMin);
+                    cylinderTMax = Vector.ConditionalSelect(useSideTriangleFace, Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, sideTriangleCylinderTMax)), cylinderTMax);
+                    localOffsetB0.X = Vector.ConditionalSelect(useSideTriangleFace, minOnTriangle.X + minToMax.X * cylinderTMin, localOffsetB0.X);
+                    localOffsetB0.Y = Vector.ConditionalSelect(useSideTriangleFace, minOnTriangle.Y + minToMax.Y * cylinderTMin, localOffsetB0.Y);
+                    localOffsetB0.Z = Vector.ConditionalSelect(useSideTriangleFace, minOnTriangle.Z + minToMax.Z * cylinderTMin, localOffsetB0.Z);
+                    localOffsetB1.X = Vector.ConditionalSelect(useSideTriangleFace, minOnTriangle.X + minToMax.X * cylinderTMax, localOffsetB1.X);
+                    localOffsetB1.Y = Vector.ConditionalSelect(useSideTriangleFace, minOnTriangle.Y + minToMax.Y * cylinderTMax, localOffsetB1.Y);
+                    localOffsetB1.Z = Vector.ConditionalSelect(useSideTriangleFace, minOnTriangle.Z + minToMax.Z * cylinderTMax, localOffsetB1.Z);
+
+                    Vector3Wide.ConditionalSelect(useVertexFallback, vertexFallback, localOffsetB0, out localOffsetB0);
+
+                    //Ray cast back to the cylinder's side to compute the depth for the contact.
+                    //t = dot(localNormal.X0Z, cylinderSideEdgeCenter - {entry, exit}) / dot(localNormal.X0Z, localNormal)
+                    var inverseDepthDenominator = Vector<float>.One / (localNormal.X * localNormal.X + localNormal.Z * localNormal.Z);
+                    depthTMin = Vector.ConditionalSelect(useSideTriangleFace, (localNormal.X * (closestOnB.X - localOffsetB0.X) + localNormal.Z * (closestOnB.Z - localOffsetB0.Z)) * inverseDepthDenominator, depthTMin);
+                    depthTMax = Vector.ConditionalSelect(useSideTriangleFace, (localNormal.X * (closestOnB.X - localOffsetB1.X) + localNormal.Z * (closestOnB.Z - localOffsetB1.Z)) * inverseDepthDenominator, depthTMax);
+                }
                 manifold.FeatureId0 = Vector.ConditionalSelect(useSide, Vector<int>.Zero, manifold.FeatureId0);
                 manifold.FeatureId1 = Vector.ConditionalSelect(useSide, Vector<int>.One, manifold.FeatureId1);
-                //depth = dot(pointOnFaceB - faceCenterA, faceNormalA) / dot(faceNormalA, normal)
-                Vector3Wide.Subtract(localContact0, triangleA, out var faceToContact0);
-                Vector3Wide.Subtract(localContact1, triangleA, out var faceToContact1);
-                Vector3Wide.Dot(faceToContact0, triangleNormal, out var contact0Dot);
-                Vector3Wide.Dot(faceToContact1, triangleNormal, out var contact1Dot);
-                var depth0 = contact0Dot * inverseFaceNormalDotLocalNormal;
-                var depth1 = contact1Dot * inverseFaceNormalDotLocalNormal;
-                manifold.Depth0 = Vector.ConditionalSelect(useSide, depth0, manifold.Depth0);
-                manifold.Depth1 = Vector.ConditionalSelect(useSide, depth1, manifold.Depth1);
-                manifold.Contact0Exists = Vector.ConditionalSelect(useSide, Vector.GreaterThan(depth0, depthThreshold), manifold.Contact0Exists);
-                manifold.Contact1Exists = Vector.ConditionalSelect(useSide, Vector.BitwiseAnd(Vector.GreaterThan(depth1, depthThreshold), Vector.GreaterThan(tMax, tMin)), manifold.Contact1Exists);
+                manifold.Depth0 = Vector.ConditionalSelect(useSide, depthTMin, manifold.Depth0);
+                manifold.Depth1 = Vector.ConditionalSelect(useSide, depthTMax, manifold.Depth1);
+                manifold.Contact0Exists = Vector.ConditionalSelect(useSide, Vector.GreaterThan(depthTMin, depthThreshold), manifold.Contact0Exists);
+                manifold.Contact1Exists = Vector.ConditionalSelect(useSide, Vector.BitwiseAnd(Vector.GreaterThan(depthTMax, depthThreshold), Vector.GreaterThan(cylinderTMax, cylinderTMin)), manifold.Contact1Exists);
                 manifold.Contact2Exists = Vector.ConditionalSelect(useSide, Vector<int>.Zero, manifold.Contact2Exists);
                 manifold.Contact3Exists = Vector.ConditionalSelect(useSide, Vector<int>.Zero, manifold.Contact3Exists);
             }
 
             Matrix3x3Wide.TransformWithoutOverlap(localNormal, worldRB, out manifold.Normal);
 
-            //Mesh reductions rely on the contact positions being on the surface of the triangle. Push the offsets accordingly.
-            Vector3Wide.Scale(manifold.Normal, manifold.Depth0, out var offset0);
-            Vector3Wide.Scale(manifold.Normal, manifold.Depth1, out var offset1);
-            Vector3Wide.Scale(manifold.Normal, manifold.Depth2, out var offset2);
-            Vector3Wide.Scale(manifold.Normal, manifold.Depth3, out var offset3);
-            Vector3Wide.Subtract(manifold.OffsetA0, offset0, out manifold.OffsetA0);
-            Vector3Wide.Subtract(manifold.OffsetA1, offset1, out manifold.OffsetA1);
-            Vector3Wide.Subtract(manifold.OffsetA2, offset2, out manifold.OffsetA2);
-            Vector3Wide.Subtract(manifold.OffsetA3, offset3, out manifold.OffsetA3);
+            Vector3Wide.Add(localOffsetB0, localOffsetB, out var localOffsetA0);
+            Vector3Wide.Add(localOffsetB1, localOffsetB, out var localOffsetA1);
+            Vector3Wide.Add(localOffsetB2, localOffsetB, out var localOffsetA2);
+            Vector3Wide.Add(localOffsetB3, localOffsetB, out var localOffsetA3);
+            Matrix3x3Wide.TransformWithoutOverlap(localOffsetA0, worldRB, out manifold.OffsetA0);
+            Matrix3x3Wide.TransformWithoutOverlap(localOffsetA1, worldRB, out manifold.OffsetA1);
+            Matrix3x3Wide.TransformWithoutOverlap(localOffsetA2, worldRB, out manifold.OffsetA2);
+            Matrix3x3Wide.TransformWithoutOverlap(localOffsetA3, worldRB, out manifold.OffsetA3);
+
             //Mesh reductions also make use of a face contact flag in the feature id.
             var faceCollisionFlag = Vector.ConditionalSelect(
                 Vector.LessThan(faceNormalADotNormal, new Vector<float>(-MeshReduction.MinimumDotForFaceCollision)), new Vector<int>(MeshReduction.FaceCollisionFlag), Vector<int>.Zero);

--- a/BepuPhysics/CollisionDetection/CollisionTasks/TrianglePairTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/TrianglePairTester.cs
@@ -42,6 +42,48 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //Protect against bad normals.
             depth = Vector.ConditionalSelect(Vector.LessThan(normalLength, new Vector<float>(1e-10f)), new Vector<float>(float.MaxValue), depth);
         }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void TestVertexNormal(in Vector3Wide vertex,
+            in Vector3Wide opposingA, in Vector3Wide opposingB, in Vector3Wide opposingC,
+            in Vector3Wide opposingAB, in Vector3Wide opposingBC, in Vector3Wide opposingCA,
+            in Vector<float> inverseLengthSquaredAB, in Vector<float> inverseLengthSquaredBC, in Vector<float> inverseLengthSquaredCA,
+            ref Vector<float> distanceSquared, ref Vector3Wide offset)
+        {
+            //Project the vertex onto all three edges. Take the closest approach as a normal candidate.
+            //Note that this will try normals that cross over the triangle's face, but that's fine- it'll just be a crappy normal candidate and another option will be chosen instead.
+            Vector3Wide.Subtract(vertex, opposingA, out var av);
+            Vector3Wide.Subtract(vertex, opposingB, out var bv);
+            Vector3Wide.Subtract(vertex, opposingC, out var cv);
+            Vector3Wide.Dot(av, opposingAB, out var avDotAB);
+            Vector3Wide.Dot(bv, opposingBC, out var bvDotBC);
+            Vector3Wide.Dot(cv, opposingCA, out var cvDotCA);
+            var tAB = Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, avDotAB * inverseLengthSquaredAB));
+            var tBC = Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, bvDotBC * inverseLengthSquaredBC));
+            var tCA = Vector.Max(Vector<float>.Zero, Vector.Min(Vector<float>.One, cvDotCA * inverseLengthSquaredCA));
+            Vector3Wide vToAB, vToBC, vToCA;
+            vToAB.X = opposingA.X + opposingAB.X * tAB - vertex.X;
+            vToAB.Y = opposingA.Y + opposingAB.Y * tAB - vertex.Y;
+            vToAB.Z = opposingA.Z + opposingAB.Z * tAB - vertex.Z;
+            vToBC.X = opposingB.X + opposingBC.X * tBC - vertex.X;
+            vToBC.Y = opposingB.Y + opposingBC.Y * tBC - vertex.Y;
+            vToBC.Z = opposingB.Z + opposingBC.Z * tBC - vertex.Z;
+            vToCA.X = opposingC.X + opposingCA.X * tCA - vertex.X;
+            vToCA.Y = opposingC.Y + opposingCA.Y * tCA - vertex.Y;
+            vToCA.Z = opposingC.Z + opposingCA.Z * tCA - vertex.Z;
+            Vector3Wide.LengthSquared(vToAB, out var abDistanceSquared);
+            Vector3Wide.LengthSquared(vToBC, out var bcDistanceSquared);
+            Vector3Wide.LengthSquared(vToCA, out var caDistanceSquared);
+
+            var distanceSquaredCandidate = Vector.Min(abDistanceSquared, Vector.Min(bcDistanceSquared, caDistanceSquared));
+            Vector3Wide.ConditionalSelect(Vector.Equals(distanceSquaredCandidate, abDistanceSquared), vToAB, vToCA, out var offsetCandidate);
+            Vector3Wide.ConditionalSelect(Vector.Equals(distanceSquaredCandidate, bcDistanceSquared), vToBC, offsetCandidate, out offsetCandidate);
+
+            var useCandidate = Vector.LessThan(distanceSquaredCandidate, distanceSquared);
+            distanceSquared = Vector.Min(distanceSquaredCandidate, distanceSquared);
+            Vector3Wide.ConditionalSelect(useCandidate, offsetCandidate, offset, out offset);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void Select(
             ref Vector<float> depth, ref Vector3Wide normal,
@@ -64,22 +106,22 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void TryAddTriangleAVertex(in Vector3Wide vertex, in Vector<int> vertexId,
+        private static void TryAddTriangleAVertex(in Vector3Wide vertex, in Vector2Wide flattenedVertex, in Vector<int> vertexId,
             in Vector3Wide tangentBX, in Vector3Wide tangentBY, in Vector3Wide triangleCenterB, in Vector3Wide contactNormal, in Vector3Wide faceNormalB,
-            in Vector3Wide edgeABPlaneNormalB, in Vector3Wide edgeBCPlaneNormalB, in Vector3Wide edgeCAPlaneNormalB, in Vector3Wide bA, in Vector3Wide bB,
-            in Vector<int> allowContacts, in Vector<float> inverseContactNormalDotFaceNormalB,
+            in Vector2Wide edgeAB, in Vector2Wide edgeBC, in Vector2Wide edgeCA, in Vector2Wide bA, in Vector2Wide bB,
+            in Vector<int> allowContacts, in Vector<float> inverseContactNormalDotFaceNormalB, in Vector<float> minimumDepth,
             ref ManifoldCandidate candidates, ref Vector<int> candidateCount, int pairCount)
         {
             //Test edge edge plane sign for all three edges of B. We can test the vertex directly rather than the unprojected vertex because the ray cast follows the contact normal,
             //and all of these plane normals are perpendicular to the contact normal.
-            Vector3Wide.Subtract(vertex, bA, out var bAToVertex);
-            Vector3Wide.Subtract(vertex, bB, out var bBToVertex);
-            Vector3Wide.Dot(bAToVertex, edgeABPlaneNormalB, out var abDot);
-            Vector3Wide.Dot(bBToVertex, edgeBCPlaneNormalB, out var bcDot);
-            Vector3Wide.Dot(bAToVertex, edgeCAPlaneNormalB, out var caDot);
-            var abContained = Vector.GreaterThan(abDot, Vector<float>.Zero);
-            var bcContained = Vector.GreaterThan(bcDot, Vector<float>.Zero);
-            var caContained = Vector.GreaterThan(caDot, Vector<float>.Zero);
+            Vector2Wide.Subtract(flattenedVertex, bA, out var bAToVertex);
+            Vector2Wide.Subtract(flattenedVertex, bB, out var bBToVertex);
+            var abEdgePlaneDot = bAToVertex.Y * edgeAB.X - bAToVertex.X * edgeAB.Y;
+            var bcEdgePlaneDot = bBToVertex.Y * edgeBC.X - bBToVertex.X * edgeBC.Y;
+            var caEdgePlaneDot = bAToVertex.Y * edgeCA.X - bAToVertex.X * edgeCA.Y;
+            var abContained = Vector.GreaterThan(abEdgePlaneDot, Vector<float>.Zero);
+            var bcContained = Vector.GreaterThan(bcEdgePlaneDot, Vector<float>.Zero);
+            var caContained = Vector.GreaterThan(caEdgePlaneDot, Vector<float>.Zero);
             var contained = Vector.BitwiseAnd(abContained, Vector.BitwiseAnd(bcContained, caContained));
 
             //Cast a ray from triangle A's vertex along the contact normal up to the plane of triangle B and check for containment.
@@ -91,52 +133,87 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //t = (vertexOnA - triangleCenterB) * faceNormalB / (contactNormal * faceNormalB)
             Vector3Wide.Subtract(triangleCenterB, vertex, out var offset);
             Vector3Wide.Dot(offset, faceNormalB, out var distance);
-            var t = distance * inverseContactNormalDotFaceNormalB;
-            Vector3Wide.Scale(contactNormal, t, out var unprojectedVertex);
+            ManifoldCandidate candidate;
+            candidate.Depth = distance * inverseContactNormalDotFaceNormalB;
+            Vector3Wide.Scale(contactNormal, candidate.Depth, out var unprojectedVertex);
             Vector3Wide.Add(unprojectedVertex, vertex, out unprojectedVertex);
 
-            ManifoldCandidate candidate;
             Vector3Wide.Subtract(unprojectedVertex, triangleCenterB, out var offsetOnB);
             Vector3Wide.Dot(offsetOnB, tangentBX, out candidate.X);
             Vector3Wide.Dot(offsetOnB, tangentBY, out candidate.Y);
             candidate.FeatureId = vertexId;
-            ManifoldCandidateHelper.AddCandidate(ref candidates, ref candidateCount, candidate, Vector.BitwiseAnd(allowContacts, contained), pairCount);
+            ManifoldCandidateHelper.AddCandidateWithDepth(ref candidates, ref candidateCount, candidate, Vector.BitwiseAnd(Vector.GreaterThanOrEqual(candidate.Depth, minimumDepth), Vector.BitwiseAnd(allowContacts, contained)), pairCount);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ClipEdge(in Vector3Wide edgeStart, in Vector3Wide edgeDirection, in Vector3Wide pointOnPlane, in Vector3Wide planeNormal, out Vector<float> entry, out Vector<float> exit)
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ClipEdge(
+            in Vector2Wide edgeStartB, in Vector2Wide edgeOffsetB,
+            in Vector2Wide edgeStartA, in Vector2Wide edgeOffsetA, in Vector<float> inverseEdgeLengthSquaredA, in Vector<float> edgeStartADotNormal, in Vector<float> edgeOffsetADotNormal,
+            out Vector<int> intersectionExists, out Vector<float> tB, out Vector<float> depthContributionA)
         {
             //The edge plane normal points toward the inside of the bounding triangle.
             //intersection = dot(planeNormal, pointOnPlane - edgeStart) / dot(planeNormal, edgeDirectionB)
-            Vector3Wide.Subtract(pointOnPlane, edgeStart, out var edgeToPlane);
-            Vector3Wide.Dot(edgeToPlane, planeNormal, out var edgePlaneNormalDot);
-            Vector3Wide.Dot(edgeDirection, planeNormal, out var velocity);
-            var t = edgePlaneNormalDot / velocity;
-            var isEntry = Vector.GreaterThanOrEqual(velocity, Vector<float>.Zero);
-            var validVelocity = Vector.GreaterThan(Vector.Abs(velocity), new Vector<float>(1e-10f));
-            entry = Vector.ConditionalSelect(Vector.BitwiseAnd(validVelocity, isEntry), t, new Vector<float>(float.MinValue));
-            exit = Vector.ConditionalSelect(Vector.AndNot(validVelocity, isEntry), t, new Vector<float>(float.MaxValue));
+            var edgePlaneNormalDot = (edgeStartA.X - edgeStartB.X) * edgeOffsetA.Y - (edgeStartA.Y - edgeStartB.Y) * edgeOffsetA.X;
+            var velocity = edgeOffsetB.X * edgeOffsetA.Y - edgeOffsetB.Y * edgeOffsetA.X;
+            var parallelThreshold = new Vector<float>(1e-20f);
+            var parallel = Vector.LessThan(Vector.Abs(velocity), parallelThreshold);
+            var denominator = Vector.ConditionalSelect(parallel, Vector.ConditionalSelect(Vector.LessThan(velocity, Vector<float>.Zero), -parallelThreshold, parallelThreshold), velocity);
+            tB = edgePlaneNormalDot / denominator;
+            //To be valid, an intersection must be within both edge bounds.
+            var intersectionPointX = tB * edgeOffsetB.X + edgeStartB.X;
+            var intersectionPointY = tB * edgeOffsetB.Y + edgeStartB.Y;
+            var tA = ((intersectionPointX - edgeStartA.X) * edgeOffsetA.X + (intersectionPointY - edgeStartA.Y) * edgeOffsetA.Y) * inverseEdgeLengthSquaredA;
+            intersectionExists = Vector.BitwiseAnd(Vector.GreaterThanOrEqual(tA, Vector<float>.Zero), Vector.LessThanOrEqual(tA, Vector<float>.One));
+            depthContributionA = edgeStartADotNormal + edgeOffsetADotNormal * tA;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ClipBEdgeAgainstABounds(
-             in Vector3Wide edgeABPlaneNormalA, in Vector3Wide edgeBCPlaneNormalA, in Vector3Wide edgeCAPlaneNormalA,
-             in Vector3Wide aA, in Vector3Wide aB,
-             in Vector3Wide edgeDirectionB, in Vector3Wide edgeStartB, in Vector<int> entryId, in Vector<int> exitIdOffset,
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ClipBEdgeAgainstABounds( //maybe we should have.. MORE parameters
+             in Vector2Wide aA, in Vector2Wide aB, in Vector2Wide aC,
+             in Vector2Wide edgeOffsetABOnA, in Vector2Wide edgeOffsetBCOnA, in Vector2Wide edgeOffsetCAOnA,
+             in Vector<float> inverseEdgeOffsetABOnALengthSquared, in Vector<float> inverseEdgeOffsetBCOnALengthSquared, in Vector<float> inverseEdgeOffsetCAOnALengthSquared,
+             in Vector<float> aDotNormalOnA, in Vector<float> bDotNormalOnA, in Vector<float> cDotNormalOnA,
+             in Vector<float> abDotNormalOnA, in Vector<float> bcDotNormalOnA, in Vector<float> caDotNormalOnA,
+             in Vector2Wide flatEdgeStartB, in Vector2Wide flatEdgeOffsetB, in Vector3Wide edgeStartB, in Vector3Wide edgeOffsetB,
+             in Vector<int> entryId, in Vector<int> exitIdOffset,
              in Vector3Wide triangleCenterB, in Vector3Wide tangentBX, in Vector3Wide tangentBY,
-             in Vector<float> epsilon, in Vector<int> allowContacts, ref ManifoldCandidate candidates, ref Vector<int> candidateCount, int pairCount)
+             in Vector3Wide localNormal, in Vector<float> minimumDepth, Vector<int> allowContacts, ref ManifoldCandidate candidates, ref Vector<int> candidateCount, int pairCount)
         {
             //The base id is the id of the vertex in the corner along the negative boxEdgeDirection and boxEdgeCenterOffsetDirection.
             //The edgeDirectionId is the amount to add when you move along the boxEdgeDirection to the other vertex.
             //The edgeCenterOffsetId is the amount to add when you move along the boxEdgeCenterOffsetDirection to the other vertex.
-
             //We have three edge planes created by the edges of triangle A.
             //We want to test the triangle B edge against all three of the edges.
-            ClipEdge(edgeStartB, edgeDirectionB, aA, edgeABPlaneNormalA, out var entryAB, out var exitAB);
-            ClipEdge(edgeStartB, edgeDirectionB, aB, edgeBCPlaneNormalA, out var entryBC, out var exitBC);
-            ClipEdge(edgeStartB, edgeDirectionB, aA, edgeCAPlaneNormalA, out var entryCA, out var exitCA);
-            var entry = Vector.Max(Vector.Max(Vector<float>.Zero, entryAB), Vector.Max(entryBC, entryCA));
-            var exit = Vector.Min(Vector.Min(Vector<float>.One, exitAB), Vector.Min(exitBC, exitCA));
+            ClipEdge(flatEdgeStartB, flatEdgeOffsetB, aA, edgeOffsetABOnA, inverseEdgeOffsetABOnALengthSquared, aDotNormalOnA, abDotNormalOnA, out var abIntersected, out var tAB, out var depthContributionABOnA);
+            ClipEdge(flatEdgeStartB, flatEdgeOffsetB, aB, edgeOffsetBCOnA, inverseEdgeOffsetBCOnALengthSquared, bDotNormalOnA, bcDotNormalOnA, out var bcIntersected, out var tBC, out var depthContributionBCOnA);
+            ClipEdge(flatEdgeStartB, flatEdgeOffsetB, aC, edgeOffsetCAOnA, inverseEdgeOffsetCAOnALengthSquared, cDotNormalOnA, caDotNormalOnA, out var caIntersected, out var tCA, out var depthContributionCAOnA);
+            var minValue = new Vector<float>(float.MinValue);
+            var maxValue = new Vector<float>(float.MaxValue);
+            var entryAB = Vector.ConditionalSelect(abIntersected, tAB, maxValue);
+            var entryBC = Vector.ConditionalSelect(bcIntersected, tBC, maxValue);
+            var entryCA = Vector.ConditionalSelect(caIntersected, tCA, maxValue);
+            var exitAB = Vector.ConditionalSelect(abIntersected, tAB, minValue);
+            var exitBC = Vector.ConditionalSelect(bcIntersected, tBC, minValue);
+            var exitCA = Vector.ConditionalSelect(caIntersected, tCA, minValue);
+            var entry = Vector.Min(entryAB, Vector.Min(entryBC, entryCA));
+            var exit = Vector.Max(exitAB, Vector.Max(exitBC, exitCA));
+            var useABAsEntry = Vector.Equals(entry, tAB);
+            var useBCAsEntry = Vector.Equals(entry, tBC);
+            //var useCAAsEntry = Vector.Equals(entry, tCA);
+            var useABAsExit = Vector.Equals(exit, tAB);
+            var useBCAsExit = Vector.Equals(exit, tBC);
+            //var useCAAsExit = Vector.Equals(exit, tCA);
+            var depthContributionAAtEntry = Vector.ConditionalSelect(useABAsEntry, depthContributionABOnA, Vector.ConditionalSelect(useBCAsEntry, depthContributionBCOnA, depthContributionCAOnA));
+            var depthContributionAAtExit = Vector.ConditionalSelect(useABAsExit, depthContributionABOnA, Vector.ConditionalSelect(useBCAsExit, depthContributionBCOnA, depthContributionCAOnA));
+            //If an edge fails to generate any interval, then it's not intersecting the triangle bounds and should not generate contacts.
+            allowContacts = Vector.AndNot(allowContacts, Vector.BitwiseOr(Vector.Equals(entry, minValue), Vector.Equals(exit, maxValue)));
+            entry = Vector.Max(Vector<float>.Zero, entry);
+            exit = Vector.Min(Vector<float>.One, exit);
+
+            Vector3Wide.Dot(edgeStartB, localNormal, out var edgeStartBDotNormal);
+            Vector3Wide.Dot(edgeOffsetB, localNormal, out var edgeOffsetBDotNormal);
+            var depthContributionBAtEntry = edgeStartBDotNormal + entry * edgeOffsetBDotNormal;
+            var depthContributionBAtExit = edgeStartBDotNormal + exit * edgeOffsetBDotNormal;
 
             //entryX = dot(entry * edgeDirectionA + edgeStartA - triangleCenterB, tangentBX)
             //entryY = dot(entry * edgeDirectionA + edgeStartA - triangleCenterB, tangentBY)
@@ -145,25 +222,27 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Vector3Wide.Subtract(edgeStartB, triangleCenterB, out var offset);
             Vector3Wide.Dot(offset, tangentBX, out var offsetX);
             Vector3Wide.Dot(offset, tangentBY, out var offsetY);
-            Vector3Wide.Dot(tangentBX, edgeDirectionB, out var edgeDirectionX);
-            Vector3Wide.Dot(tangentBY, edgeDirectionB, out var edgeDirectionY);
+            Vector3Wide.Dot(tangentBX, edgeOffsetB, out var edgeDirectionX);
+            Vector3Wide.Dot(tangentBY, edgeOffsetB, out var edgeDirectionY);
 
             ManifoldCandidate candidate;
             var six = new Vector<int>(6);
             //Entry
-            var exists = Vector.BitwiseAnd(allowContacts, Vector.BitwiseAnd(
+            candidate.Depth = depthContributionBAtEntry - depthContributionAAtEntry;
+            var exists = Vector.BitwiseAnd(Vector.BitwiseAnd(allowContacts, Vector.GreaterThanOrEqual(candidate.Depth, minimumDepth)), Vector.BitwiseAnd(
                 Vector.BitwiseAnd(
                     Vector.LessThan(candidateCount, six),
-                    Vector.GreaterThanOrEqual(exit - entry, epsilon)),
+                    Vector.GreaterThanOrEqual(exit - entry, new Vector<float>(1e-5f))), //note fixed threshold; the exit and entry values are in terms of the edge's length already. 
                 Vector.BitwiseAnd(
                     Vector.LessThan(entry, Vector<float>.One),
                     Vector.GreaterThan(entry, Vector<float>.Zero))));
             candidate.X = entry * edgeDirectionX + offsetX;
             candidate.Y = entry * edgeDirectionY + offsetY;
             candidate.FeatureId = entryId;
-            ManifoldCandidateHelper.AddCandidate(ref candidates, ref candidateCount, candidate, exists, pairCount);
+            ManifoldCandidateHelper.AddCandidateWithDepth(ref candidates, ref candidateCount, candidate, exists, pairCount);
             //Exit
-            exists = Vector.BitwiseAnd(allowContacts, Vector.BitwiseAnd(
+            candidate.Depth = depthContributionBAtExit - depthContributionAAtExit;
+            exists = Vector.BitwiseAnd(Vector.BitwiseAnd(allowContacts, Vector.GreaterThanOrEqual(candidate.Depth, minimumDepth)), Vector.BitwiseAnd(
                 Vector.BitwiseAnd(
                     Vector.LessThan(candidateCount, six),
                     Vector.GreaterThanOrEqual(exit, entry)),
@@ -173,12 +252,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             candidate.X = exit * edgeDirectionX + offsetX;
             candidate.Y = exit * edgeDirectionY + offsetY;
             candidate.FeatureId = entryId + exitIdOffset;
-            ManifoldCandidateHelper.AddCandidate(ref candidates, ref candidateCount, candidate, exists, pairCount);
+            ManifoldCandidateHelper.AddCandidateWithDepth(ref candidates, ref candidateCount, candidate, exists, pairCount);
         }
 
 
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void Test(
             ref TriangleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
@@ -210,6 +289,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Vector3Wide.Subtract(a.B, a.A, out var abA);
             Vector3Wide.Subtract(a.C, a.B, out var bcA);
             Vector3Wide.Subtract(a.A, a.C, out var caA);
+
 
             //A AB x *
             TestEdgeEdge(abA, abB, a.A, a.B, a.C, bA, bB, bC, out var depth, out var localNormal);
@@ -246,6 +326,44 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             GetDepthForNormal(a.A, a.B, a.C, bA, bB, bC, faceNormalB, out var faceDepthB);
             Select(ref depth, ref localNormal, faceDepthB, faceNormalB);
 
+            Vector3Wide.LengthSquared(abA, out var abALengthSquared);
+            Vector3Wide.LengthSquared(abB, out var abBLengthSquared);
+            Vector3Wide.LengthSquared(caA, out var caALengthSquared);
+            Vector3Wide.LengthSquared(caB, out var caBLengthSquared);
+            var allowContacts = BundleIndexing.CreateMaskForCountInBundle(pairCount);
+            //The following was created for MeshReduction when it demanded all contact normals be correct during separation.
+            //Other pairs don't have that requirement, and we ended modifying MeshReduction to be a little less picky.
+            //This remains for posterity because, hey, it works, and if you need it, there it is.
+            //var tryVertexNormals = Vector.BitwiseAnd(Vector.LessThan(depth, Vector<float>.Zero), allowContacts);
+            //if (Vector.LessThanAny(tryVertexNormals, Vector<int>.Zero))
+            //{
+            //    //Vertex normals are not required to determine penetration versus separation. They are only used to ensure correct separated speculative normals.
+            //    //This isn't strictly required for behavior in the general case, but MeshReduction depends on it.
+            //    Vector3Wide.LengthSquared(bcA, out var bcALengthSquared);
+            //    Vector3Wide.LengthSquared(bcB, out var bcBLengthSquared);
+            //    var inverseABALengthSquared = Vector<float>.One / abALengthSquared;
+            //    var inverseBCALengthSquared = Vector<float>.One / bcALengthSquared;
+            //    var inverseCAALengthSquared = Vector<float>.One / caALengthSquared;
+            //    var inverseABBLengthSquared = Vector<float>.One / abBLengthSquared;
+            //    var inverseBCBLengthSquared = Vector<float>.One / bcBLengthSquared;
+            //    var inverseCABLengthSquared = Vector<float>.One / caBLengthSquared;
+            //    var distanceSquared = new Vector<float>(float.MaxValue);
+            //    Unsafe.SkipInit(out Vector3Wide offset);
+            //    TestVertexNormal(a.A, bA, bB, bC, abB, bcB, caB, inverseABBLengthSquared, inverseBCBLengthSquared, inverseCABLengthSquared, ref distanceSquared, ref offset);
+            //    TestVertexNormal(a.B, bA, bB, bC, abB, bcB, caB, inverseABBLengthSquared, inverseBCBLengthSquared, inverseCABLengthSquared, ref distanceSquared, ref offset);
+            //    TestVertexNormal(a.C, bA, bB, bC, abB, bcB, caB, inverseABBLengthSquared, inverseBCBLengthSquared, inverseCABLengthSquared, ref distanceSquared, ref offset);
+            //    TestVertexNormal(bA, a.A, a.B, a.C, abA, bcA, caA, inverseABALengthSquared, inverseBCALengthSquared, inverseCAALengthSquared, ref distanceSquared, ref offset);
+            //    TestVertexNormal(bB, a.A, a.B, a.C, abA, bcA, caA, inverseABALengthSquared, inverseBCALengthSquared, inverseCAALengthSquared, ref distanceSquared, ref offset);
+            //    TestVertexNormal(bC, a.A, a.B, a.C, abA, bcA, caA, inverseABALengthSquared, inverseBCALengthSquared, inverseCAALengthSquared, ref distanceSquared, ref offset);
+
+            //    var distance = Vector.SquareRoot(distanceSquared);
+            //    Vector3Wide.Scale(offset, Vector<float>.One / distance, out localNormalCandidate);
+            //    //Don't try to use distances that are so small that the resulting normal will be numerically bad. That's close enough to intersecting that the previous normals will handle it.
+            //    GetDepthForNormal(a.A, a.B, a.C, bA, bB, bC, localNormalCandidate, out depthCandidate);
+            //    depthCandidate = Vector.ConditionalSelect(Vector.GreaterThan(distance, new Vector<float>(1e-7f)), depthCandidate, new Vector<float>(float.MaxValue));
+            //    Select(ref depth, ref localNormal, depthCandidate, localNormalCandidate);
+            //}
+
             //Point the normal from B to A by convention.
             Vector3Wide.Subtract(localTriangleCenterB, localTriangleCenterA, out var centerAToCenterB);
             Vector3Wide.Dot(localNormal, centerAToCenterB, out var calibrationDot);
@@ -254,13 +372,18 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             localNormal.Y = Vector.ConditionalSelect(shouldFlip, -localNormal.Y, localNormal.Y);
             localNormal.Z = Vector.ConditionalSelect(shouldFlip, -localNormal.Z, localNormal.Z);
 
+            var minimumDepth = -speculativeMargin;
             Vector3Wide.Dot(localNormal, faceNormalA, out var localNormalDotFaceNormalA);
             Vector3Wide.Dot(localNormal, faceNormalB, out var localNormalDotFaceNormalB);
-            //We're going to avoid generating contacts for triangles with normals very near 90 degrees off from the collision normal.
-            //This helps avoid some numerical issues, although it does introduce a quirk- a dotThreshold of 1e-4f corresponds to no collisions being generated within the last degree or so away from the face normal (roughly).
-            //An edge with an angle smaller than this simply won't generate contacts.
-            const float dotThreshold = 1e-4f;
-            var allowContacts = Vector.BitwiseAnd(Vector.LessThan(localNormalDotFaceNormalA, new Vector<float>(-dotThreshold)), Vector.GreaterThan(localNormalDotFaceNormalB, new Vector<float>(dotThreshold)));
+            TriangleWide.ComputeNondegenerateTriangleMask(abALengthSquared, caALengthSquared, faceNormalALength, out var epsilonScaleA, out var nondegenerateMaskA);
+            TriangleWide.ComputeNondegenerateTriangleMask(abBLengthSquared, caBLengthSquared, faceNormalBLength, out var epsilonScaleB, out var nondegenerateMaskB);
+            allowContacts = Vector.BitwiseAnd(
+                Vector.BitwiseAnd(nondegenerateMaskA, nondegenerateMaskB),
+                Vector.BitwiseAnd(
+                    Vector.BitwiseAnd(Vector.GreaterThanOrEqual(depth, minimumDepth), allowContacts),
+                    Vector.BitwiseAnd(
+                        Vector.LessThan(localNormalDotFaceNormalA, new Vector<float>(-TriangleWide.BackfaceNormalDotRejectionThreshold)),
+                        Vector.GreaterThan(localNormalDotFaceNormalB, new Vector<float>(TriangleWide.BackfaceNormalDotRejectionThreshold)))));
             if (Vector.EqualsAll(allowContacts, Vector<int>.Zero))
             {
                 manifold.Contact0Exists = default;
@@ -273,58 +396,95 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //At this point, we have computed the minimum depth and associated local normal.
             //We now need to compute some contact locations, their per-contact depths, and the feature ids.
 
-            //Contact generation always assumes face-face clipping. Other forms of contact generation are just special cases of face-face, and since we pay
-            //for all code paths, there's no point in handling them separately.            
+            //Flatten both triangles onto a plane with normal equal to the detected local normal to perform clipping.
+            //Note that the final result does not depend on the orientation of the flattening basis, so we can just use the orthonormal builder.
+            Helpers.BuildOrthonormalBasis(localNormal, out var flattenX, out var flattenY);
+            Vector2Wide flatVertexAOnA, flatVertexBOnA, flatVertexCOnA;
+            Vector2Wide flatVertexAOnB, flatVertexBOnB, flatVertexCOnB;
+            Vector3Wide.Dot(a.A, flattenX, out flatVertexAOnA.X);
+            Vector3Wide.Dot(a.A, flattenY, out flatVertexAOnA.Y);
+            Vector3Wide.Dot(a.B, flattenX, out flatVertexBOnA.X);
+            Vector3Wide.Dot(a.B, flattenY, out flatVertexBOnA.Y);
+            Vector3Wide.Dot(a.C, flattenX, out flatVertexCOnA.X);
+            Vector3Wide.Dot(a.C, flattenY, out flatVertexCOnA.Y);
+            Vector3Wide.Dot(bA, flattenX, out flatVertexAOnB.X);
+            Vector3Wide.Dot(bA, flattenY, out flatVertexAOnB.Y);
+            Vector3Wide.Dot(bB, flattenX, out flatVertexBOnB.X);
+            Vector3Wide.Dot(bB, flattenY, out flatVertexBOnB.Y);
+            Vector3Wide.Dot(bC, flattenX, out flatVertexCOnB.X);
+            Vector3Wide.Dot(bC, flattenY, out flatVertexCOnB.Y);
 
-            //We will be working on the surface of the triangle, but we'd still like a 2d parameterization of the surface for contact reduction.
+            Vector2Wide.Subtract(flatVertexBOnA, flatVertexAOnA, out var flatEdgeABOnA);
+            Vector2Wide.Subtract(flatVertexCOnA, flatVertexBOnA, out var flatEdgeBCOnA);
+            Vector2Wide.Subtract(flatVertexAOnA, flatVertexCOnA, out var flatEdgeCAOnA);
+            Vector2Wide.Subtract(flatVertexBOnB, flatVertexAOnB, out var flatEdgeABOnB);
+            Vector2Wide.Subtract(flatVertexCOnB, flatVertexBOnB, out var flatEdgeBCOnB);
+            Vector2Wide.Subtract(flatVertexAOnB, flatVertexCOnB, out var flatEdgeCAOnB);
+
+            var edgeThreshold = new Vector<float>(0.2f);
+            var useEdgeCaseForA = Vector.LessThan(Vector.Abs(localNormalDotFaceNormalA), edgeThreshold);
+            var useEdgeCaseForB = Vector.LessThan(Vector.Abs(localNormalDotFaceNormalB), edgeThreshold);
+            var useFaceCaseForA = Vector.OnesComplement(useEdgeCaseForA);
+            var useFaceCaseForB = Vector.OnesComplement(useEdgeCaseForB);
+            useEdgeCaseForA = Vector.BitwiseAnd(allowContacts, useEdgeCaseForA);
+            useEdgeCaseForB = Vector.BitwiseAnd(allowContacts, useEdgeCaseForB);
+            useFaceCaseForA = Vector.BitwiseAnd(allowContacts, useFaceCaseForA);
+            useFaceCaseForB = Vector.BitwiseAnd(allowContacts, useFaceCaseForB);
+
+            //We will be working on the surface of triangleB, but we'd still like a 2d parameterization of the surface for contact reduction.
             //So, we'll create tangent axes from the edge and edge x normal.
-            Vector3Wide.LengthSquared(abB, out var abBLengthSquared);
             Vector3Wide.Scale(abB, Vector<float>.One / Vector.SquareRoot(abBLengthSquared), out var tangentBX);
             Vector3Wide.CrossWithoutOverlap(tangentBX, faceNormalB, out var tangentBY);
 
             //Note that we only allocate up to 6 candidates. Each triangle edge can contribute at most two contacts (any more would require a nonconvex clip region).
             //Numerical issues can cause more to occur, but they're guarded against (both directly, and in the sense of checking count before adding any candidates beyond the sixth).
-            int byteCount = Unsafe.SizeOf<ManifoldCandidate>() * 6;
-            var buffer = stackalloc byte[byteCount];
+            var buffer = stackalloc ManifoldCandidate[6];
             var candidateCount = Vector<int>.Zero;
-            ref var candidates = ref Unsafe.As<byte, ManifoldCandidate>(ref *buffer);
+            ref var candidates = ref *buffer;
 
-            //While the edge clipping will find any edge-edge or aVertex-bFace contacts, it will not find bVertex-aFace contacts.
-            //Add them independently.
-            //(Adding these first allows us to simply skip capacity tests, since there can only be a total of three bVertex-aFace contacts.)
-            //Note that division by zero is protected by allowContacts.
-            var inverseContactNormalDotFaceNormalB = Vector<float>.One / localNormalDotFaceNormalB;
-            Vector3Wide.CrossWithoutOverlap(abB, localNormal, out var edgeABPlaneNormalB);
-            Vector3Wide.CrossWithoutOverlap(bcB, localNormal, out var edgeBCPlaneNormalB);
-            Vector3Wide.CrossWithoutOverlap(caB, localNormal, out var edgeCAPlaneNormalB);
-            TryAddTriangleAVertex(a.A, Vector<int>.Zero, tangentBX, tangentBY, localTriangleCenterB, localNormal, faceNormalB, edgeABPlaneNormalB, edgeBCPlaneNormalB, edgeCAPlaneNormalB, bA, bB, allowContacts, inverseContactNormalDotFaceNormalB, ref candidates, ref candidateCount, pairCount);
-            TryAddTriangleAVertex(a.B, Vector<int>.One, tangentBX, tangentBY, localTriangleCenterB, localNormal, faceNormalB, edgeABPlaneNormalB, edgeBCPlaneNormalB, edgeCAPlaneNormalB, bA, bB, allowContacts, inverseContactNormalDotFaceNormalB, ref candidates, ref candidateCount, pairCount);
-            TryAddTriangleAVertex(a.C, new Vector<int>(2), tangentBX, tangentBY, localTriangleCenterB, localNormal, faceNormalB, edgeABPlaneNormalB, edgeBCPlaneNormalB, edgeCAPlaneNormalB, bA, bB, allowContacts, inverseContactNormalDotFaceNormalB, ref candidates, ref candidateCount, pairCount);
-
-            //Note that edge cases will also add triangle A vertices that are within triangle B's bounds, so no A vertex case is required.
-            //Note that each of these calls can generate 4 contacts, so we have to start checking capacities.
-
-            //Create a scale-sensitive epsilon for comparisons based on the size of the involved shapes. This helps avoid varying behavior based on how large involved objects are.
-            Vector3Wide.LengthSquared(abA, out var abALengthSquared);
-            Vector3Wide.LengthSquared(caA, out var caALengthSquared);
-            Vector3Wide.LengthSquared(caB, out var caBLengthSquared);
-            var epsilonScale = Vector.SquareRoot(Vector.Min(
-                Vector.Max(abALengthSquared, caALengthSquared),
-                Vector.Max(abBLengthSquared, caBLengthSquared)));
-            var edgeEpsilon = new Vector<float>(1e-5f) * epsilonScale;
-            var exitIdOffset = new Vector<int>(3);
+            if (Vector.LessThanAny(useFaceCaseForB, Vector<int>.Zero))
+            {
+                //While the edge clipping will find any edge-edge or bVertex-aFace contacts, it will not find aVertex-bFace contacts.
+                //Add them independently.
+                //(Adding these first allows us to simply skip capacity tests, since there can only be a total of three bVertex-aFace contacts.)
+                //Note that division by zero is protected by useFaceCaseForB. These contacts aren't relevant for the edge case anyway.
+                var inverseContactNormalDotFaceNormalB = Vector<float>.One / localNormalDotFaceNormalB;
+                TryAddTriangleAVertex(a.A, flatVertexAOnA, Vector<int>.Zero, tangentBX, tangentBY, localTriangleCenterB, localNormal, faceNormalB, flatEdgeABOnB, flatEdgeBCOnB, flatEdgeCAOnB, flatVertexAOnB, flatVertexBOnB, useFaceCaseForB, inverseContactNormalDotFaceNormalB, minimumDepth, ref candidates, ref candidateCount, pairCount);
+                TryAddTriangleAVertex(a.B, flatVertexBOnA, Vector<int>.One, tangentBX, tangentBY, localTriangleCenterB, localNormal, faceNormalB, flatEdgeABOnB, flatEdgeBCOnB, flatEdgeCAOnB, flatVertexAOnB, flatVertexBOnB, useFaceCaseForB, inverseContactNormalDotFaceNormalB, minimumDepth, ref candidates, ref candidateCount, pairCount);
+                TryAddTriangleAVertex(a.C, flatVertexCOnA, new Vector<int>(2), tangentBX, tangentBY, localTriangleCenterB, localNormal, faceNormalB, flatEdgeABOnB, flatEdgeBCOnB, flatEdgeCAOnB, flatVertexAOnB, flatVertexBOnB, useFaceCaseForB, inverseContactNormalDotFaceNormalB, minimumDepth, ref candidates, ref candidateCount, pairCount);
+            }
+            //Note that edge cases will also add triangle B vertices that are within triangle A's bounds, so no B vertex case is required.
+            var three = new Vector<int>(3);
             //Note the use of localNormal here, NOT faceNormalA. Why? Just like in the vertexA case, we're not creating contacts in triangle A's face voronoi region.
             //Instead, the test region is skewed along the contact normal. These planes intersect A's edges and have the contact normal as a tangent.
-            //This avoids dependency on pair order (consider what happens when A and B swap) and produces nicer contacts in corner cases (consider two near perpendicular triangles).
-            Vector3Wide.CrossWithoutOverlap(localNormal, abA, out var edgeABPlaneNormalA);
-            Vector3Wide.CrossWithoutOverlap(localNormal, bcA, out var edgeBCPlaneNormalA);
-            Vector3Wide.CrossWithoutOverlap(localNormal, caA, out var edgeCAPlaneNormalA);
-            ClipBEdgeAgainstABounds(edgeABPlaneNormalA, edgeBCPlaneNormalA, edgeCAPlaneNormalA, a.A, a.B, abB, bA, new Vector<int>(3), exitIdOffset, localTriangleCenterB, tangentBX, tangentBY, edgeEpsilon, allowContacts, ref candidates, ref candidateCount, pairCount);
-            ClipBEdgeAgainstABounds(edgeABPlaneNormalA, edgeBCPlaneNormalA, edgeCAPlaneNormalA, a.A, a.B, bcB, bB, new Vector<int>(4), exitIdOffset, localTriangleCenterB, tangentBX, tangentBY, edgeEpsilon, allowContacts, ref candidates, ref candidateCount, pairCount);
-            ClipBEdgeAgainstABounds(edgeABPlaneNormalA, edgeBCPlaneNormalA, edgeCAPlaneNormalA, a.A, a.B, caB, bC, new Vector<int>(5), exitIdOffset, localTriangleCenterB, tangentBX, tangentBY, edgeEpsilon, allowContacts, ref candidates, ref candidateCount, pairCount);
+            //This avoids dependency on pair order (consider what happens when A and B swap).
+            var stillCouldUseClippingContacts = Vector.BitwiseAnd(allowContacts, Vector.LessThan(candidateCount, three));
+            if (Vector.LessThanAny(stillCouldUseClippingContacts, Vector<int>.Zero))
+            {
+                //At least one lane may need edge clipped contacts.
+                Vector2Wide.LengthSquared(flatEdgeABOnA, out var flatEdgeOffsetABOnALengthSquared);
+                Vector2Wide.LengthSquared(flatEdgeBCOnA, out var flatEdgeOffsetBCOnALengthSquared);
+                Vector2Wide.LengthSquared(flatEdgeCAOnA, out var flatEdgeOffsetCAOnALengthSquared);
+                var inverseFlatEdgeOffsetABOnALengthSquared = Vector<float>.One / flatEdgeOffsetABOnALengthSquared;
+                var inverseFlatEdgeOffsetBCOnALengthSquared = Vector<float>.One / flatEdgeOffsetBCOnALengthSquared;
+                var inverseFlatEdgeOffsetCAOnALengthSquared = Vector<float>.One / flatEdgeOffsetCAOnALengthSquared;
+                //These clipping routines compute depth directly, rather than relying on reduction to compute it for us (thanks, triangles).
+                //We can precompute the depth contribution for A's edges.
+                Vector3Wide.Dot(localNormal, a.A, out var aDotNormalOnA);
+                Vector3Wide.Dot(localNormal, a.B, out var bDotNormalOnA);
+                Vector3Wide.Dot(localNormal, a.C, out var cDotNormalOnA);
+                Vector3Wide.Dot(localNormal, abA, out var abDotNormalOnA);
+                Vector3Wide.Dot(localNormal, bcA, out var bcDotNormalOnA);
+                Vector3Wide.Dot(localNormal, caA, out var caDotNormalOnA);
+                ClipBEdgeAgainstABounds(flatVertexAOnA, flatVertexBOnA, flatVertexCOnA, flatEdgeABOnA, flatEdgeBCOnA, flatEdgeCAOnA, inverseFlatEdgeOffsetABOnALengthSquared, inverseFlatEdgeOffsetBCOnALengthSquared, inverseFlatEdgeOffsetCAOnALengthSquared, aDotNormalOnA, bDotNormalOnA, cDotNormalOnA, abDotNormalOnA, bcDotNormalOnA, caDotNormalOnA, flatVertexAOnB, flatEdgeABOnB, bA, abB, new Vector<int>(3), three, localTriangleCenterB, tangentBX, tangentBY, localNormal, minimumDepth, stillCouldUseClippingContacts, ref candidates, ref candidateCount, pairCount);
+                ClipBEdgeAgainstABounds(flatVertexAOnA, flatVertexBOnA, flatVertexCOnA, flatEdgeABOnA, flatEdgeBCOnA, flatEdgeCAOnA, inverseFlatEdgeOffsetABOnALengthSquared, inverseFlatEdgeOffsetBCOnALengthSquared, inverseFlatEdgeOffsetCAOnALengthSquared, aDotNormalOnA, bDotNormalOnA, cDotNormalOnA, abDotNormalOnA, bcDotNormalOnA, caDotNormalOnA, flatVertexBOnB, flatEdgeBCOnB, bB, bcB, new Vector<int>(4), three, localTriangleCenterB, tangentBX, tangentBY, localNormal, minimumDepth, stillCouldUseClippingContacts, ref candidates, ref candidateCount, pairCount);
+                ClipBEdgeAgainstABounds(flatVertexAOnA, flatVertexBOnA, flatVertexCOnA, flatEdgeABOnA, flatEdgeBCOnA, flatEdgeCAOnA, inverseFlatEdgeOffsetABOnALengthSquared, inverseFlatEdgeOffsetBCOnALengthSquared, inverseFlatEdgeOffsetCAOnALengthSquared, aDotNormalOnA, bDotNormalOnA, cDotNormalOnA, abDotNormalOnA, bcDotNormalOnA, caDotNormalOnA, flatVertexCOnB, flatEdgeCAOnB, bC, caB, new Vector<int>(5), three, localTriangleCenterB, tangentBX, tangentBY, localNormal, minimumDepth, stillCouldUseClippingContacts, ref candidates, ref candidateCount, pairCount);
+            }
 
-            Vector3Wide.Subtract(localTriangleCenterA, localTriangleCenterB, out var faceCenterBToFaceCenterA);
-            ManifoldCandidateHelper.Reduce(ref candidates, candidateCount, 6, faceNormalA, localNormal, faceCenterBToFaceCenterA, tangentBX, tangentBY, epsilonScale, -speculativeMargin, pairCount,
+            //Create a scale-sensitive epsilon for comparisons based on the size of the involved shapes. This helps avoid varying behavior based on how large involved objects are.
+            var epsilonScale = Vector.Min(epsilonScaleA, epsilonScaleB);
+            var edgeEpsilon = new Vector<float>(1e-5f) * epsilonScale;
+            ManifoldCandidateHelper.ReduceWithoutComputingDepths(ref candidates, candidateCount, 6, epsilonScale, minimumDepth, pairCount,
                 out var contact0, out var contact1, out var contact2, out var contact3,
                 out manifold.Contact0Exists, out manifold.Contact1Exists, out manifold.Contact2Exists, out manifold.Contact3Exists);
 

--- a/BepuPhysics/CollisionDetection/CompoundMeshReduction.cs
+++ b/BepuPhysics/CollisionDetection/CompoundMeshReduction.cs
@@ -24,6 +24,7 @@ namespace BepuPhysics.CollisionDetection
         public Quaternion MeshOrientation;
         //This uses all of the nonconvex reduction's logic, so we just nest it.
         public NonconvexReduction Inner;
+        public unsafe Mesh* Mesh { get; set; }
 
         public void Create(int childManifoldCount, BufferPool pool)
         {

--- a/BepuUtilities/BundleIndexing.cs
+++ b/BepuUtilities/BundleIndexing.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace BepuUtilities
-{    
+{
     /// <summary>
     /// Some helpers for indexing into vector bundles.
     /// </summary>
@@ -17,11 +17,9 @@ namespace BepuUtilities
         public static int VectorMask
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return Vector<float>.Count - 1;
-            }
+            get { return Vector<float>.Count - 1; }
         }
+
         /// <summary>
         /// <![CDATA[Gets the shift value such that x >> VectorShift divides x by Vector<float>.Count.]]>
         /// </summary>
@@ -56,6 +54,33 @@ namespace BepuUtilities
         public static int GetBundleCount(int elementCount)
         {
             return (elementCount + VectorMask) >> VectorShift;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe Vector<int> CreateTrailingMaskForCountInBundle(int countInBundle)
+        {
+            Vector<int> mask;
+            var toReturnPointer = (int*) &mask;
+            for (int i = 0; i < Vector<int>.Count; ++i)
+            {
+                toReturnPointer[i] = countInBundle <= i ? -1 : 0;
+            }
+
+            return mask;
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe Vector<int> CreateMaskForCountInBundle(int countInBundle)
+        {
+            Vector<int> mask;
+            var toReturnPointer = (int*) &mask;
+            for (int i = 0; i < Vector<int>.Count; ++i)
+            {
+                toReturnPointer[i] = countInBundle > i ? -1 : 0;
+            }
+
+            return mask;
         }
     }
 }


### PR DESCRIPTION
In the latest version 2.4 the issue that meshes sometimes cannot create contact manifold on collision is solved. To get this bug fixed in 2.3.1, ported all triangle test from 2.4 to 2.3.1