### PR TITLE
Consider enabling Source Link support

### DIFF
--- a/BepuPhysics/BepuPhysics.csproj
+++ b/BepuPhysics/BepuPhysics.csproj
@@ -21,6 +21,9 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--<TieredCompilation>false</TieredCompilation>-->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -81,6 +84,11 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <!-- Needed for Source Link package debugging, see https://github.com/dotnet/sourcelink -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/BepuPhysics/BepuPhysics.csproj
+++ b/BepuPhysics/BepuPhysics.csproj
@@ -21,7 +21,6 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--<TieredCompilation>false</TieredCompilation>-->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/BepuUtilities/BepuUtilities.csproj
+++ b/BepuUtilities/BepuUtilities.csproj
@@ -22,6 +22,9 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--<TieredCompilation>false</TieredCompilation>-->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -39,6 +42,11 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <!-- Needed for Source Link package debugging, see https://github.com/dotnet/sourcelink -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/BepuUtilities/BepuUtilities.csproj
+++ b/BepuUtilities/BepuUtilities.csproj
@@ -22,7 +22,6 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--<TieredCompilation>false</TieredCompilation>-->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
I notice your (fantastic!) physics library doesn't include any debugging support in the NuGet package. Please consider enabling Source Link (see https://github.com/dotnet/sourcelink) to enable this. Source Link enables VS2017+/Rider users to debug into the source code of your library without any hassle or extra steps. Apart from the project file changes, it does require one extra step from you when uploading a new package version to the NuGet website: there is an extra "snupkg" file that is generated alongside the "nupkg" file, which also needs to be uploaded. (More info on this file can be found here: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg)

EDIT: I believe your existing "dotnet nuget push to nuget.org" action will upload the symbols package automatically (if they exist in the same folder), so at second glance there should be no extra steps required to build a release.