### PR TITLE
Added missing texture format (R8G8B8A8_UNorm_SRgb) to exception message

### DIFF
--- a/DemoRenderer.GL/UI/RenderableImage.cs
+++ b/DemoRenderer.GL/UI/RenderableImage.cs
@@ -26,7 +26,7 @@ namespace DemoRenderer.UI
         {
             if (imageContent.TexelSizeInBytes != 4)
             {
-                throw new ArgumentException("The renderable image assumes an R8G8B8A8_UNorm or  texture.");
+                throw new ArgumentException("The renderable image assumes an R8G8B8A8_UNorm or R8G8B8A8_UNorm_SRgb texture.");
             }
             Debug.Assert(imageContent.MipLevels == 1, "We ignore any mip levels stored in the content; if the content pipeline output them, something's likely mismatched.");
             Content = imageContent;

--- a/DemoRenderer/UI/RenderableImage.cs
+++ b/DemoRenderer/UI/RenderableImage.cs
@@ -50,7 +50,7 @@ namespace DemoRenderer.UI
         {
             if (imageContent.TexelSizeInBytes != 4)
             {
-                throw new ArgumentException("The renderable image assumes an R8G8B8A8_UNorm or  texture.");
+                throw new ArgumentException("The renderable image assumes an R8G8B8A8_UNorm or R8G8B8A8_UNorm_SRgb texture.");
             }
             Debug.Assert(imageContent.MipLevels == 1, "We ignore any mip levels stored in the content; if the content pipeline output them, something's likely mismatched.");
             Initialize(device, imageContent.Width, imageContent.Height, srgb, debugName);


### PR DESCRIPTION
RenderableImage supports R8G8B8A8_UNorm and R8G8B8A8_UNorm_SRgb texture formats, but the latter is missing in the exception message.