### PR TITLE
Ability to pass command line args to BDN

### DIFF
--- a/DemoBenchmarks/CollisionBatcherTasks.cs
+++ b/DemoBenchmarks/CollisionBatcherTasks.cs
@@ -139,7 +139,7 @@ public class CollisionBatcherTasks
     }
 
     [Benchmark]
-    public unsafe Vector3 Benchmark()
+    public unsafe Vector3 CollisionBatcherTasksBenchmark()
     {
         CollisionBatcher<Callbacks> batcher = new(pool, shapes, taskRegistry, 1 / 60f, new Callbacks());
 

--- a/DemoBenchmarks/DemoBenchmarks.csproj
+++ b/DemoBenchmarks/DemoBenchmarks.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/DemoBenchmarks/Program.cs
+++ b/DemoBenchmarks/Program.cs
@@ -1,15 +1,10 @@
 ﻿using BenchmarkDotNet.Running;
 using DemoBenchmarks;
 
-BenchmarkRunner.Run(typeof(OneBodyConstraintBenchmarks));
-BenchmarkRunner.Run(typeof(TwoBodyConstraintBenchmarks));
-BenchmarkRunner.Run(typeof(ThreeBodyConstraintBenchmarks));
-BenchmarkRunner.Run(typeof(FourBodyConstraintBenchmarks));
-BenchmarkRunner.Run(typeof(ConvexCollisionTesters));
-BenchmarkRunner.Run(typeof(CollisionBatcherTasks));
-BenchmarkRunner.Run(typeof(Sweeps));
-BenchmarkRunner.Run(typeof(ShapeRayTests));
-BenchmarkRunner.Run(typeof(GatherScatter));
-BenchmarkRunner.Run(typeof(RagdollTubeBenchmark));
-BenchmarkRunner.Run(typeof(ShapePileBenchmark));
-
+public class BepuPhysics2Benchmarks
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkSwitcher.FromAssembly(typeof(BepuPhysics2Benchmarks).Assembly).Run(args);
+    }
+}

--- a/DemoBenchmarks/RagdollTubeBenchmark.cs
+++ b/DemoBenchmarks/RagdollTubeBenchmark.cs
@@ -584,7 +584,7 @@ public class RagdollTubeBenchmark
     }
 
     [Benchmark]
-    public unsafe void Benchmark()
+    public unsafe void RagdollTubeBenchmarks()
     {
         for (int i = 0; i < timestepCount; ++i)
         {

--- a/DemoBenchmarks/ShapePileBenchmark.cs
+++ b/DemoBenchmarks/ShapePileBenchmark.cs
@@ -221,7 +221,7 @@ public class ShapePileBenchmark
     }
 
     [Benchmark]
-    public unsafe void Benchmark()
+    public unsafe void ShapePileBenchmarks()
     {
         for (int i = 0; i < timestepCount; ++i)
         {


### PR DESCRIPTION
- This change uses `BenchmarkSwitcher` to pass the arguments to BDN so the `--filter` or `--help` can work
- It also updates the name of certain benchmarks to easily identify them in the report.