### PR TITLE
Fix build error with 2.4.0

### DIFF
--- a/DemoBenchmarks/ShapeRayBenchmarksDeep.cs
+++ b/DemoBenchmarks/ShapeRayBenchmarksDeep.cs
@@ -69,7 +69,7 @@ public class ShapeRayBenchmarksDeep
             return true;
         }
 
-        public void OnRayHit(in RayData ray, ref float maximumT, float t, Vector3 normal, int childIndex)
+        public void OnRayHit(in RayData ray, ref float maximumT, float t, in Vector3 normal, int childIndex)
         {
             ResultSum += new Vector3(t) + normal;
         }


### PR DESCRIPTION
Fix the following error:

```
D:\git\performance\src\benchmarks\real-world\bepuphysics2\ShapeRayBenchmarksDeep.cs(63,25): error CS0535: 'ShapeRayBenc
hmarksDeep.HitHandler' does not implement interface member 'IShapeRayHitHandler.OnRayHit(in RayData, ref float, float,
in Vector3, int)' [D:\git\performance\src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj]
```