### PR TITLE
Add Net6 LTS support for the nuget package

### DIFF
--- a/BepuPhysics/BepuPhysics.csproj
+++ b/BepuPhysics/BepuPhysics.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Version>2.5.0-beta.9</Version>
     <Company>Bepu Entertainment LLC</Company>
     <Authors>Ross Nordby</Authors>
@@ -87,7 +87,7 @@
 
   <!-- Needed for Source Link package debugging, see https://github.com/dotnet/sourcelink -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/BepuUtilities/BepuUtilities.csproj
+++ b/BepuUtilities/BepuUtilities.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>BepuUtilities</AssemblyName>
     <RootNamespace>BepuUtilities</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Version>2.5.0-beta.9</Version>
     <Company>Bepu Entertainment LLC</Company>
     <Authors>Ross Nordby</Authors>
@@ -45,7 +45,7 @@
 
   <!-- Needed for Source Link package debugging, see https://github.com/dotnet/sourcelink -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
A lot of things still use net6 for example Godot engine still hasn't updated to net 7 and I would like to be able to use bepu in my net 6 projects and net 6 is LTS it's the end of support is November 12, 2024 while net 7 is May 14, 2024