### PR TITLE
Utilize static virtual members

### DIFF
--- a/BepuPhysics/Collidables/BigCompound.cs
+++ b/BepuPhysics/Collidables/BigCompound.cs
@@ -203,7 +203,7 @@ namespace BepuPhysics.Collidables
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapes)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapes)
         {
             return new CompoundShapeBatch<BigCompound>(pool, initialCapacity, shapes);
         }
@@ -342,7 +342,7 @@ namespace BepuPhysics.Collidables
         /// Type id of compound shapes.
         /// </summary>
         public const int Id = 7;
-        public int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
 

--- a/BepuPhysics/Collidables/Box.cs
+++ b/BepuPhysics/Collidables/Box.cs
@@ -162,7 +162,7 @@ namespace BepuPhysics.Collidables
             return inertia;
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
         {
             return new ConvexShapeBatch<Box, BoxWide>(pool, initialCapacity);
         }
@@ -171,7 +171,7 @@ namespace BepuPhysics.Collidables
         /// Type id of box shapes.
         /// </summary>
         public const int Id = 2;
-        public readonly int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
 
@@ -221,7 +221,7 @@ namespace BepuPhysics.Collidables
             maximumAngularExpansion = maximumRadius - Vector.Min(HalfLength, Vector.Min(HalfHeight, HalfLength));
         }
 
-        public int MinimumWideRayCount
+        public static int MinimumWideRayCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get

--- a/BepuPhysics/Collidables/Capsule.cs
+++ b/BepuPhysics/Collidables/Capsule.cs
@@ -179,7 +179,7 @@ namespace BepuPhysics.Collidables
             return inertia;
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
         {
             return new ConvexShapeBatch<Capsule, CapsuleWide>(pool, initialCapacity);
         }
@@ -190,7 +190,7 @@ namespace BepuPhysics.Collidables
         /// Type id of capsule shapes.
         /// </summary>
         public const int Id = 1;
-        public readonly int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
     public struct CapsuleWide : IShapeWide<Capsule>
@@ -238,7 +238,7 @@ namespace BepuPhysics.Collidables
             maximumAngularExpansion = HalfLength;
         }
 
-        public int MinimumWideRayCount
+        public static int MinimumWideRayCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get

--- a/BepuPhysics/Collidables/Compound.cs
+++ b/BepuPhysics/Collidables/Compound.cs
@@ -250,7 +250,7 @@ namespace BepuPhysics.Collidables
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapes)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapes)
         {
             return new CompoundShapeBatch<Compound>(pool, initialCapacity, shapes);
         }
@@ -371,7 +371,7 @@ namespace BepuPhysics.Collidables
         /// Type id of list based compound shapes.
         /// </summary>
         public const int Id = 6;
-        public int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
 

--- a/BepuPhysics/Collidables/ConvexHull.cs
+++ b/BepuPhysics/Collidables/ConvexHull.cs
@@ -193,7 +193,7 @@ namespace BepuPhysics.Collidables
             return inertia;
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
         {
             return new ConvexHullShapeBatch(pool, initialCapacity);
         }
@@ -282,7 +282,7 @@ namespace BepuPhysics.Collidables
         /// Type id of convex hull shapes.
         /// </summary>
         public const int Id = 5;
-        public readonly int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
     public struct ConvexHullWide : IShapeWide<ConvexHull>
@@ -291,7 +291,7 @@ namespace BepuPhysics.Collidables
         //The "wide" variant is simply a collection of convex hull instances.
         public Buffer<ConvexHull> Hulls;
 
-        public int MinimumWideRayCount => int.MaxValue; //'Wide' ray tests just fall through to scalar tests anyway.
+        public static int MinimumWideRayCount => int.MaxValue; //'Wide' ray tests just fall through to scalar tests anyway.
 
         public bool AllowOffsetMemoryAccess => false;
         public int InternalAllocationSize => Vector<float>.Count * Unsafe.SizeOf<ConvexHull>();

--- a/BepuPhysics/Collidables/Cylinder.cs
+++ b/BepuPhysics/Collidables/Cylinder.cs
@@ -176,7 +176,7 @@ namespace BepuPhysics.Collidables
             return inertia;
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
         {
             return new ConvexShapeBatch<Cylinder, CylinderWide>(pool, initialCapacity);
         }
@@ -185,7 +185,7 @@ namespace BepuPhysics.Collidables
         /// Type id of cylinder shapes.
         /// </summary>
         public const int Id = 4;
-        public readonly int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
     public struct CylinderWide : IShapeWide<Cylinder>
@@ -233,7 +233,7 @@ namespace BepuPhysics.Collidables
             maximumAngularExpansion = maximumRadius - Vector.Min(HalfLength, Radius);
         }
 
-        public int MinimumWideRayCount
+        public static int MinimumWideRayCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get

--- a/BepuPhysics/Collidables/IShape.cs
+++ b/BepuPhysics/Collidables/IShape.cs
@@ -14,11 +14,10 @@ namespace BepuPhysics.Collidables
     /// </summary>
     public interface IShape
     {
-        //TODO: Note that these should really be *static* as they do not need any information about an instance, but static abstract interface methods are not yet out of preview.
         /// <summary>
         /// Unique type id for this shape type.
         /// </summary>
-        int TypeId { get; }
+        static abstract int TypeId { get; }
         /// <summary>
         /// Creates a shape batch for this type of shape.
         /// </summary>
@@ -26,9 +25,8 @@ namespace BepuPhysics.Collidables
         /// <param name="initialCapacity">Initial capacity to allocate within the batch.</param>
         /// <param name="shapeBatches">The set of shapes to contain this batch.</param>
         /// <returns>Shape batch for the shape type.</returns>
-        /// <remarks>This is typically used internally to initialize new shape collections in response to shapes being added. It is not likely to be useful outside of the engine.
-        /// Ideally, this would be implemented as a static abstract, but those aren't available yet.</remarks>
-        ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches);
+        /// <remarks>This is typically used internally to initialize new shape collections in response to shapes being added. It is not likely to be useful outside of the engine.</remarks>
+        static abstract ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches);
     }
 
     //Note that the following bounds functions require only an orientation because the effect of the position on the bounding box is the same for all shapes.
@@ -263,7 +261,7 @@ namespace BepuPhysics.Collidables
         /// <summary>
         /// Gets the lower bound on the number of rays to execute in a wide fashion. Ray bundles with fewer rays will fall back to the single ray code path.
         /// </summary>
-        int MinimumWideRayCount { get; }
+        static abstract int MinimumWideRayCount { get; }
 
         /// <summary>
         /// Tests a ray against the shape.

--- a/BepuPhysics/Collidables/Mesh.cs
+++ b/BepuPhysics/Collidables/Mesh.cs
@@ -255,7 +255,7 @@ namespace BepuPhysics.Collidables
             }
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
         {
             return new HomogeneousCompoundShapeBatch<Mesh, Triangle, TriangleWide>(pool, initialCapacity);
         }
@@ -544,7 +544,7 @@ namespace BepuPhysics.Collidables
         /// Type id of mesh shapes.
         /// </summary>
         public const int Id = 8;
-        public readonly int TypeId => Id;
+        public static int TypeId => Id;
 
     }
 }

--- a/BepuPhysics/Collidables/Shapes.cs
+++ b/BepuPhysics/Collidables/Shapes.cs
@@ -136,7 +136,7 @@ namespace BepuPhysics.Collidables
         protected ShapeBatch(BufferPool pool, int initialShapeCount)
         {
             this.pool = pool;
-            TypeId = default(TShape).TypeId;
+            TypeId = TShape.TypeId;
             InternalResize(initialShapeCount, 0);
             idPool = new IdPool(initialShapeCount, pool);
         }
@@ -433,14 +433,14 @@ namespace BepuPhysics.Collidables
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref TShape GetShape<TShape>(int shapeIndex) where TShape : unmanaged, IShape
         {
-            var typeId = default(TShape).TypeId;
+            var typeId = TShape.TypeId;
             return ref Unsafe.As<ShapeBatch, ShapeBatch<TShape>>(ref batches[typeId])[shapeIndex];
         }
 
 
         public TypedIndex Add<TShape>(in TShape shape) where TShape : unmanaged, IShape
         {
-            var typeId = default(TShape).TypeId;
+            var typeId = TShape.TypeId;
             if (RegisteredTypeSpan <= typeId)
             {
                 registeredTypeSpan = typeId + 1;
@@ -451,7 +451,7 @@ namespace BepuPhysics.Collidables
             }
             if (batches[typeId] == null)
             {
-                batches[typeId] = default(TShape).CreateShapeBatch(pool, InitialCapacityPerTypeBatch, this);
+                batches[typeId] = TShape.CreateShapeBatch(pool, InitialCapacityPerTypeBatch, this);
             }
 
             Debug.Assert(batches[typeId] is ShapeBatch<TShape>);

--- a/BepuPhysics/Collidables/Sphere.cs
+++ b/BepuPhysics/Collidables/Sphere.cs
@@ -108,7 +108,7 @@ namespace BepuPhysics.Collidables
             return inertia;
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapes)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapes)
         {
             return new ConvexShapeBatch<Sphere, SphereWide>(pool, initialCapacity);
         }
@@ -118,7 +118,7 @@ namespace BepuPhysics.Collidables
         /// Type id of sphere shapes.
         /// </summary>
         public const int Id = 0;
-        public readonly int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
     public struct SphereWide : IShapeWide<Sphere>
@@ -163,7 +163,7 @@ namespace BepuPhysics.Collidables
         }
 
 
-        public int MinimumWideRayCount
+        public static int MinimumWideRayCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get

--- a/BepuPhysics/Collidables/Triangle.cs
+++ b/BepuPhysics/Collidables/Triangle.cs
@@ -118,7 +118,7 @@ namespace BepuPhysics.Collidables
             return inertia;
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
         {
             return new ConvexShapeBatch<Triangle, TriangleWide>(pool, initialCapacity);
         }
@@ -127,7 +127,7 @@ namespace BepuPhysics.Collidables
         /// Type id of triangle shapes.
         /// </summary>
         public const int Id = 3;
-        public readonly int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
+        public static int TypeId { [MethodImpl(MethodImplOptions.AggressiveInlining)] get { return Id; } }
     }
 
 
@@ -220,7 +220,7 @@ namespace BepuPhysics.Collidables
             maximumAngularExpansion = maximumRadius;
         }
 
-        public int MinimumWideRayCount
+        public static int MinimumWideRayCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get

--- a/BepuPhysics/CollisionDetection/CollisionBatcher.cs
+++ b/BepuPhysics/CollisionDetection/CollisionBatcher.cs
@@ -281,7 +281,7 @@ namespace BepuPhysics.CollisionDetection
             //that's actually used by the narrowphase (and which will likely be used for most performance sensitive cases).
             //TODO: You could recover the performance and safety once generic pointers exist. By having pointers in the parameter list, we can require that the user handle GC safety.
             //(We could also have an explicit 'unsafe' overload, but that API complexity doesn't seem worthwhile. My guess is nontrivial uses will all use the underlying function directly.)
-            Add(shapeA.TypeId, shapeB.TypeId, Unsafe.SizeOf<TShapeA>(), Unsafe.SizeOf<TShapeB>(), Unsafe.AsPointer(ref shapeA), Unsafe.AsPointer(ref shapeB),
+            Add(TShapeA.TypeId, TShapeB.TypeId, Unsafe.SizeOf<TShapeA>(), Unsafe.SizeOf<TShapeB>(), Unsafe.AsPointer(ref shapeA), Unsafe.AsPointer(ref shapeB),
                 offsetB, orientationA, orientationB, speculativeMargin, pairId);
         }
 

--- a/BepuPhysics/CollisionDetection/CollisionTaskRegistry.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTaskRegistry.cs
@@ -276,7 +276,7 @@ namespace BepuPhysics.CollisionDetection
             where TShapeA : unmanaged, IShape
             where TShapeB : unmanaged, IShape
         {
-            return ref GetTaskReference(default(TShapeA).TypeId, default(TShapeB).TypeId);
+            return ref GetTaskReference(TShapeA.TypeId, TShapeB.TypeId);
         }
     }
 }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/BoxConvexHullTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/BoxConvexHullTester.cs
@@ -10,9 +10,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct BoxConvexHullTester : IPairTester<BoxWide, ConvexHullWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
-        public unsafe void Test(ref BoxWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static unsafe void Test(ref BoxWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             Unsafe.SkipInit(out manifold);
             Matrix3x3Wide.CreateFromQuaternion(orientationA, out var boxOrientation);
@@ -360,12 +360,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Matrix3x3Wide.TransformWithoutOverlap(localNormal, hullOrientation, out manifold.Normal);
         }
 
-        public void Test(ref BoxWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref BoxWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/BoxCylinderTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/BoxCylinderTester.cs
@@ -11,7 +11,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
     using DepthRefiner = DepthRefiner<Cylinder, CylinderWide, CylinderSupportFinder, Box, BoxWide, BoxSupportFinder>;
     public struct BoxCylinderTester : IPairTester<BoxWide, CylinderWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void IntersectLineCircle(in Vector2Wide linePosition, in Vector2Wide lineDirection, in Vector<float> radius, out Vector<float> tMin, out Vector<float> tMax, out Vector<int> intersected)
@@ -100,7 +100,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Test(
+        public static unsafe void Test(
             ref BoxWide a, ref CylinderWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex4ContactManifoldWide manifold)
@@ -386,12 +386,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
 
-        public void Test(ref BoxWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref BoxWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/BoxPairTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/BoxPairTester.cs
@@ -10,7 +10,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct BoxPairTester : IPairTester<BoxWide, BoxWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void TestEdgeEdge(
@@ -322,7 +322,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Test(
+        public static unsafe void Test(
             ref BoxWide a, ref BoxWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex4ContactManifoldWide manifold)
@@ -539,12 +539,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifoldFeatureId = rawContact.FeatureId;
         }
 
-        public void Test(ref BoxWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref BoxWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/BoxTriangleTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/BoxTriangleTester.cs
@@ -9,7 +9,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct BoxTriangleTester : IPairTester<BoxWide, TriangleWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void GetDepthForInterval(in Vector<float> boxExtreme, in Vector<float> a, in Vector<float> b, in Vector<float> c, out Vector<float> depth)
@@ -278,7 +278,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Test(
+        public static unsafe void Test(
             ref BoxWide a, ref TriangleWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex4ContactManifoldWide manifold)
@@ -701,12 +701,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifoldFeatureId = rawContact.FeatureId;
         }
 
-        public void Test(ref BoxWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref BoxWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref BoxWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleBoxTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleBoxTester.cs
@@ -8,7 +8,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct CapsuleBoxTester : IPairTester<CapsuleWide, BoxWide, Convex2ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Prepare(
@@ -174,7 +174,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(
+        public static void Test(
             ref CapsuleWide a, ref BoxWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex2ContactManifoldWide manifold)
@@ -344,12 +344,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                 Vector.GreaterThan(tMax - tMin, new Vector<float>(1e-7f) * a.HalfLength));
         }
 
-        public void Test(ref CapsuleWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref CapsuleWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleConvexHullTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleConvexHullTester.cs
@@ -9,9 +9,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct CapsuleConvexHullTester : IPairTester<CapsuleWide, ConvexHullWide, Convex2ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
-        public void Test(ref CapsuleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             Matrix3x3Wide.CreateFromQuaternion(orientationA, out var capsuleOrientation);
             Matrix3x3Wide.CreateFromQuaternion(orientationB, out var hullOrientation);
@@ -179,12 +179,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 
         }
 
-        public void Test(ref CapsuleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref CapsuleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleCylinderTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleCylinderTester.cs
@@ -9,7 +9,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct CapsuleCylinderTester : IPairTester<CapsuleWide, CylinderWide, Convex2ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Bounce(in Vector3Wide lineOrigin, in Vector3Wide lineDirection, in Vector<float> t, in CylinderWide b, in Vector<float> radiusSquared, out Vector3Wide p, out Vector3Wide clamped)
@@ -132,7 +132,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(ref CapsuleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             //Potential normal generators:
             //Capsule endpoint vs cylinder cap plane :
@@ -345,12 +345,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
 
-        public void Test(ref CapsuleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref CapsuleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CapsulePairTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CapsulePairTester.cs
@@ -8,10 +8,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct CapsulePairTester : IPairTester<CapsuleWide, CapsuleWide, Convex2ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(
+        public static void Test(
             ref CapsuleWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex2ContactManifoldWide manifold)
@@ -128,12 +128,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //Worth looking into later.
         }
 
-        public void Test(ref CapsuleWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref CapsuleWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleTriangleTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CapsuleTriangleTester.cs
@@ -9,7 +9,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct CapsuleTriangleTester : IPairTester<CapsuleWide, TriangleWide, Convex2ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
         public static void TestEdge(in TriangleWide triangle, in Vector3Wide triangleNormal,
             in Vector3Wide edgeStart, in Vector3Wide edgeOffset,
@@ -110,7 +110,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(
+        public static void Test(
             ref CapsuleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex2ContactManifoldWide manifold)
@@ -381,12 +381,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
 
-        public void Test(ref CapsuleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref CapsuleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
+        public static void Test(ref CapsuleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex2ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CompoundMeshContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CompoundMeshContinuations.cs
@@ -67,7 +67,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //In other words, we can pass a pointer to it to avoid the need for additional batcher shape copying.
             ref var triangle = ref continuation.Triangles[continuationChildIndex];
             childShapeDataB = Unsafe.AsPointer(ref triangle);
-            childTypeB = triangle.TypeId;
+            childTypeB = Triangle.TypeId;
             Unsafe.AsRef<TMesh>(pair.B).GetLocalChild(childIndexB, out continuation.Triangles[continuationChildIndex]);
             ref var continuationChild = ref continuation.Inner.Children[continuationChildIndex];
             //In meshes, the triangle's vertices already contain the offset, so there is no additional offset.                                 

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CompoundPairOverlapFinder.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CompoundPairOverlapFinder.cs
@@ -20,7 +20,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         where TCompoundB : struct, IBoundsQueryableCompound
     {
 
-        public unsafe void FindLocalOverlaps(ref Buffer<BoundsTestedPair> pairs, int pairCount, BufferPool pool, Shapes shapes, float dt, out CompoundPairOverlaps overlaps)
+        public static unsafe void FindLocalOverlaps(ref Buffer<BoundsTestedPair> pairs, int pairCount, BufferPool pool, Shapes shapes, float dt, out CompoundPairOverlaps overlaps)
         {
             var totalCompoundChildCount = 0;
             for (int i = 0; i < pairCount; ++i)

--- a/BepuPhysics/CollisionDetection/CollisionTasks/ConvexCompoundCollisionTask.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/ConvexCompoundCollisionTask.cs
@@ -32,8 +32,8 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public ConvexCompoundCollisionTask()
         {
             BatchSize = 16;
-            ShapeTypeIndexA = default(TConvex).TypeId;
-            ShapeTypeIndexB = default(TCompound).TypeId;
+            ShapeTypeIndexA = TConvex.TypeId;
+            ShapeTypeIndexB = TCompound.TypeId;
             SubtaskGenerator = true;
             PairType = CollisionTaskPairType.BoundsTestedPair;
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/ConvexHullPairTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/ConvexHullPairTester.cs
@@ -15,9 +15,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             public Vector3 EdgePlaneNormal;
             public float MaximumContainmentDot;
         }
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
-        public unsafe void Test(ref ConvexHullWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static unsafe void Test(ref ConvexHullWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             Unsafe.SkipInit(out manifold);
             Matrix3x3Wide.CreateFromQuaternion(orientationA, out var rA);
@@ -225,12 +225,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Matrix3x3Wide.TransformWithoutOverlap(localNormal, rB, out manifold.Normal);
         }
 
-        public void Test(ref ConvexHullWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref ConvexHullWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref ConvexHullWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref ConvexHullWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/ConvexMeshContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/ConvexMeshContinuations.cs
@@ -35,7 +35,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //In other words, we can pass a pointer to it to avoid the need for additional batcher shape copying.
             ref var triangle = ref continuation.Triangles[continuationChildIndex];
             childShapeDataB = Unsafe.AsPointer(ref triangle);
-            childTypeB = triangle.TypeId;
+            childTypeB = Triangle.TypeId;
             Unsafe.AsRef<TMesh>(pair.B).GetLocalChild(childIndex, out continuation.Triangles[continuationChildIndex]);
             ref var continuationChild = ref continuation.Inner.Children[continuationChildIndex];
             //Triangles already have their local pose baked into their vertices, so we just need the orientation.

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CylinderConvexHullTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CylinderConvexHullTester.cs
@@ -9,7 +9,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct CylinderConvexHullTester : IPairTester<CylinderWide, ConvexHullWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void ProjectOntoCap(Vector3 capCenter, in Matrix3x3 cylinderOrientation, float inverseLocalNormalDotAY, Vector3 localNormal, Vector3 point, out Vector2 projected)
@@ -81,7 +81,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             GatherScatter.GetFirst(ref contactExistsWide) = -1;
         }
 
-        public unsafe void Test(ref CylinderWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static unsafe void Test(ref CylinderWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             Unsafe.SkipInit(out manifold);
             Matrix3x3Wide.CreateFromQuaternion(orientationA, out var cylinderOrientation);
@@ -407,12 +407,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             Vector3Wide.Add(manifold.OffsetA3, offset3, out manifold.OffsetA3);
         }
 
-        public void Test(ref CylinderWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref CylinderWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref CylinderWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref CylinderWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CylinderPairTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CylinderPairTester.cs
@@ -12,7 +12,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 
     public struct CylinderPairTester : IPairTester<CylinderWide, CylinderWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void ProjectOntoCapA(in Vector<float> capCenterBY, in Vector3Wide capCenterA, in Matrix3x3Wide rA, in Vector<float> inverseNDotAY, in Vector3Wide localNormal, in Vector2Wide point, out Vector2Wide projected)
@@ -95,7 +95,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(
+        public static void Test(
             ref CylinderWide a, ref CylinderWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex4ContactManifoldWide manifold)
@@ -447,12 +447,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifold.FeatureId3 = new Vector<int>(3);
         }
 
-        public void Test(ref CylinderWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref CylinderWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref CylinderWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref CylinderWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairContinuations.cs
@@ -56,7 +56,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         {
             ref var triangle = ref continuation.Triangles[triangleAStartIndex++];
             childShapeDataA = Unsafe.AsPointer(ref triangle);
-            childTypeA = triangle.TypeId;
+            childTypeA = Triangle.TypeId;
             Unsafe.AsRef<TMeshA>(pair.A).GetLocalChild(childIndexA, out triangle);
             childPoseA = new RigidPose(default, pair.OrientationA);
         }
@@ -71,7 +71,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             //In other words, we can pass a pointer to it to avoid the need for additional batcher shape copying.
             ref var triangle = ref continuation.Triangles[continuationChildIndex];
             childShapeDataB = Unsafe.AsPointer(ref triangle);
-            childTypeB = triangle.TypeId;
+            childTypeB = Triangle.TypeId;
             Unsafe.AsRef<TMeshB>(pair.B).GetLocalChild(childIndexB, out continuation.Triangles[continuationChildIndex]);
             ref var continuationChild = ref continuation.Inner.Children[continuationChildIndex];
             //In meshes, the triangle's vertices already contain the offset, so there is no additional offset.                                 

--- a/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairOverlapFinder.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairOverlapFinder.cs
@@ -15,7 +15,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         where TMeshB : struct, IHomogeneousCompoundShape<Triangle, TriangleWide>
     {
 
-        public unsafe void FindLocalOverlaps(ref Buffer<BoundsTestedPair> pairs, int pairCount, BufferPool pool, Shapes shapes, float dt, out CompoundPairOverlaps overlaps)
+        public static unsafe void FindLocalOverlaps(ref Buffer<BoundsTestedPair> pairs, int pairCount, BufferPool pool, Shapes shapes, float dt, out CompoundPairOverlaps overlaps)
         {
             var totalCompoundChildCount = 0;
             for (int i = 0; i < pairCount; ++i)

--- a/BepuPhysics/CollisionDetection/CollisionTasks/PairTypes.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/PairTypes.cs
@@ -21,8 +21,8 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         /// <summary>
         /// Gets the enumeration type associated with this pair type.
         /// </summary>
-        CollisionTaskPairType PairType { get; }
-        ref PairContinuation GetContinuation(ref TPair pair);
+        static abstract CollisionTaskPairType PairType { get; }
+        static abstract ref PairContinuation GetContinuation(ref TPair pair);
     }
 
     public unsafe struct CollisionPair : ICollisionPair<CollisionPair>
@@ -39,10 +39,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public float SpeculativeMargin;
         public PairContinuation Continuation;
 
-        public readonly CollisionTaskPairType PairType => CollisionTaskPairType.StandardPair;
+        public static CollisionTaskPairType PairType => CollisionTaskPairType.StandardPair;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref PairContinuation GetContinuation(ref CollisionPair pair)
+        public static ref PairContinuation GetContinuation(ref CollisionPair pair)
         {
             return ref pair.Continuation;
         }
@@ -58,10 +58,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public float SpeculativeMargin;
         public PairContinuation Continuation;
 
-        public readonly CollisionTaskPairType PairType => CollisionTaskPairType.FliplessPair;
+        public static CollisionTaskPairType PairType => CollisionTaskPairType.FliplessPair;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref PairContinuation GetContinuation(ref FliplessPair pair)
+        public static ref PairContinuation GetContinuation(ref FliplessPair pair)
         {
             return ref pair.Continuation;
         }
@@ -75,10 +75,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public float SpeculativeMargin;
         public PairContinuation Continuation;
 
-        public readonly CollisionTaskPairType PairType => CollisionTaskPairType.SpherePair;
+        public static CollisionTaskPairType PairType => CollisionTaskPairType.SpherePair;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref PairContinuation GetContinuation(ref SpherePair pair)
+        public static ref PairContinuation GetContinuation(ref SpherePair pair)
         {
             return ref pair.Continuation;
         }
@@ -97,10 +97,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public float SpeculativeMargin;
         public PairContinuation Continuation;
 
-        public readonly CollisionTaskPairType PairType => CollisionTaskPairType.SphereIncludingPair;
+        public static CollisionTaskPairType PairType => CollisionTaskPairType.SphereIncludingPair;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref PairContinuation GetContinuation(ref SphereIncludingPair pair)
+        public static ref PairContinuation GetContinuation(ref SphereIncludingPair pair)
         {
             return ref pair.Continuation;
         }
@@ -125,10 +125,10 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public float SpeculativeMargin;
         public PairContinuation Continuation;
 
-        public readonly CollisionTaskPairType PairType => CollisionTaskPairType.BoundsTestedPair;
+        public static CollisionTaskPairType PairType => CollisionTaskPairType.BoundsTestedPair;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref PairContinuation GetContinuation(ref BoundsTestedPair pair)
+        public static ref PairContinuation GetContinuation(ref BoundsTestedPair pair)
         {
             return ref pair.Continuation;
         }
@@ -138,16 +138,16 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         where TShapeA : struct, IShape where TShapeB : struct, IShape
         where TShapeWideA : struct, IShapeWide<TShapeA> where TShapeWideB : struct, IShapeWide<TShapeB>
     {
-        bool HasFlipMask { get; }
-        int OrientationCount { get; }
+        static abstract bool HasFlipMask { get; }
+        static abstract int OrientationCount { get; }
         //Note the pair parameter. This is just to get around the fact that you cannot ref return struct fields like you can with classes, at least right now
-        ref Vector<int> GetFlipMask(ref TPairWide pair);
-        ref Vector<float> GetSpeculativeMargin(ref TPairWide pair);
-        ref TShapeWideA GetShapeA(ref TPairWide pair);
-        ref TShapeWideB GetShapeB(ref TPairWide pair);
-        ref QuaternionWide GetOrientationA(ref TPairWide pair);
-        ref QuaternionWide GetOrientationB(ref TPairWide pair);
-        ref Vector3Wide GetOffsetB(ref TPairWide pair);
+        static abstract ref Vector<int> GetFlipMask(ref TPairWide pair);
+        static abstract ref Vector<float> GetSpeculativeMargin(ref TPairWide pair);
+        static abstract ref TShapeWideA GetShapeA(ref TPairWide pair);
+        static abstract ref TShapeWideB GetShapeB(ref TPairWide pair);
+        static abstract ref QuaternionWide GetOrientationA(ref TPairWide pair);
+        static abstract ref QuaternionWide GetOrientationB(ref TPairWide pair);
+        static abstract ref Vector3Wide GetOffsetB(ref TPairWide pair);
         void WriteSlot(int index, in TPair source);
 
     }
@@ -166,51 +166,51 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public QuaternionWide OrientationB;
         public Vector<float> SpeculativeMargin;
 
-        public bool HasFlipMask
+        public static bool HasFlipMask
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return true; }
         }
 
-        public int OrientationCount
+        public static int OrientationCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return 2; }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<int> GetFlipMask(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
+        public static ref Vector<int> GetFlipMask(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
         {
             return ref pair.FlipMask;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetSpeculativeMargin(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
+        public static ref Vector<float> GetSpeculativeMargin(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
         {
             return ref pair.SpeculativeMargin;
         }
         //Little unfortunate that we can't return ref of struct instances.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref TShapeWideA GetShapeA(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
+        public static ref TShapeWideA GetShapeA(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
         {
             return ref pair.A;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref TShapeWideB GetShapeB(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
+        public static ref TShapeWideB GetShapeB(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
         {
             return ref pair.B;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
+        public static ref Vector3Wide GetOffsetB(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
         {
             return ref pair.OffsetB;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref QuaternionWide GetOrientationA(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
+        public static ref QuaternionWide GetOrientationA(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
         {
             return ref pair.OrientationA;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref QuaternionWide GetOrientationB(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
+        public static ref QuaternionWide GetOrientationB(ref ConvexPairWide<TShapeA, TShapeWideA, TShapeB, TShapeWideB> pair)
         {
             return ref pair.OrientationB;
         }
@@ -243,50 +243,50 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public QuaternionWide OrientationB;
         public Vector<float> SpeculativeMargin;
 
-        public bool HasFlipMask
+        public static bool HasFlipMask
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return false; }
         }
 
-        public int OrientationCount
+        public static int OrientationCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return 2; }
         }
 
-        public ref Vector<int> GetFlipMask(ref FliplessPairWide<TShape, TShapeWide> pair)
+        public static ref Vector<int> GetFlipMask(ref FliplessPairWide<TShape, TShapeWide> pair)
         {
             throw new NotImplementedException();
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetSpeculativeMargin(ref FliplessPairWide<TShape, TShapeWide> pair)
+        public static ref Vector<float> GetSpeculativeMargin(ref FliplessPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.SpeculativeMargin;
         }
         //Little unfortunate that we can't return ref of struct instances.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref TShapeWide GetShapeA(ref FliplessPairWide<TShape, TShapeWide> pair)
+        public static ref TShapeWide GetShapeA(ref FliplessPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.A;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref TShapeWide GetShapeB(ref FliplessPairWide<TShape, TShapeWide> pair)
+        public static ref TShapeWide GetShapeB(ref FliplessPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.B;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref FliplessPairWide<TShape, TShapeWide> pair)
+        public static ref Vector3Wide GetOffsetB(ref FliplessPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.OffsetB;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref QuaternionWide GetOrientationA(ref FliplessPairWide<TShape, TShapeWide> pair)
+        public static ref QuaternionWide GetOrientationA(ref FliplessPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.OrientationA;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref QuaternionWide GetOrientationB(ref FliplessPairWide<TShape, TShapeWide> pair)
+        public static ref QuaternionWide GetOrientationB(ref FliplessPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.OrientationB;
         }
@@ -320,51 +320,51 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public QuaternionWide OrientationB;
         public Vector<float> SpeculativeMargin;
 
-        public bool HasFlipMask
+        public static bool HasFlipMask
         {
             //Because the shapes are guaranteed to be distinct (one is apparently a sphere and the other isn't), there will always be a flip mask.
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return true; }
         }
 
-        public int OrientationCount
+        public static int OrientationCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return 1; }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<int> GetFlipMask(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
+        public static ref Vector<int> GetFlipMask(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.FlipMask;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetSpeculativeMargin(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
+        public static ref Vector<float> GetSpeculativeMargin(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.SpeculativeMargin;
         }
         //Little unfortunate that we can't return ref of struct instances.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref SphereWide GetShapeA(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
+        public static ref SphereWide GetShapeA(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.A;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref TShapeWide GetShapeB(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
+        public static ref TShapeWide GetShapeB(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.B;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
+        public static ref Vector3Wide GetOffsetB(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.OffsetB;
         }
-        public ref QuaternionWide GetOrientationA(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
+        public static ref QuaternionWide GetOrientationA(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
         {
             throw new NotImplementedException();
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref QuaternionWide GetOrientationB(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
+        public static ref QuaternionWide GetOrientationB(ref SphereIncludingPairWide<TShape, TShapeWide> pair)
         {
             return ref pair.OrientationB;
         }
@@ -390,47 +390,47 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         public Vector3Wide OffsetB;
         public Vector<float> SpeculativeMargin;
 
-        public bool HasFlipMask
+        public static bool HasFlipMask
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return false; }
         }
-        public int OrientationCount
+        public static int OrientationCount
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get { return 0; }
         }
 
-        public ref Vector<int> GetFlipMask(ref SpherePairWide pair)
+        public static ref Vector<int> GetFlipMask(ref SpherePairWide pair)
         {
             throw new NotImplementedException();
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetSpeculativeMargin(ref SpherePairWide pair)
+        public static ref Vector<float> GetSpeculativeMargin(ref SpherePairWide pair)
         {
             return ref pair.SpeculativeMargin;
         }
         //Little unfortunate that we can't return ref of struct instances.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref SphereWide GetShapeA(ref SpherePairWide pair)
+        public static ref SphereWide GetShapeA(ref SpherePairWide pair)
         {
             return ref pair.A;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref SphereWide GetShapeB(ref SpherePairWide pair)
+        public static ref SphereWide GetShapeB(ref SpherePairWide pair)
         {
             return ref pair.B;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref SpherePairWide pair)
+        public static ref Vector3Wide GetOffsetB(ref SpherePairWide pair)
         {
             return ref pair.OffsetB;
         }
-        public ref QuaternionWide GetOrientationA(ref SpherePairWide pair)
+        public static ref QuaternionWide GetOrientationA(ref SpherePairWide pair)
         {
             throw new NotImplementedException();
         }
-        public ref QuaternionWide GetOrientationB(ref SpherePairWide pair)
+        public static ref QuaternionWide GetOrientationB(ref SpherePairWide pair)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/SphereBoxTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/SphereBoxTester.cs
@@ -9,15 +9,15 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
     //Individual pair testers are designed to be used outside of the narrow phase. They need to be usable for queries and such, so all necessary data must be gathered externally.
     public struct SphereBoxTester : IPairTester<SphereWide, BoxWide, Convex1ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
-        public void Test(ref SphereWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(ref SphereWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             //Clamp the position of the sphere to the box.
             Matrix3x3Wide.CreateFromQuaternion(orientationB, out var orientationMatrixB);
@@ -64,7 +64,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifold.ContactExists = Vector.GreaterThan(manifold.Depth, -speculativeMargin);
         }
 
-        public void Test(ref SphereWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref BoxWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/SphereCapsuleTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/SphereCapsuleTester.cs
@@ -9,15 +9,15 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
     //Individual pair testers are designed to be used outside of the narrow phase. They need to be usable for queries and such, so all necessary data must be gathered externally.
     public struct SphereCapsuleTester : IPairTester<SphereWide, CapsuleWide, Convex1ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
-        public void Test(ref SphereWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(ref SphereWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             //The contact for a sphere-capsule pair is based on the closest point of the sphere center to the capsule internal line segment.
             QuaternionWide.TransformUnitXY(orientationB, out var x, out var y);
@@ -48,7 +48,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifold.ContactExists = Vector.GreaterThan(manifold.Depth, -speculativeMargin);
         }
 
-        public void Test(ref SphereWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref CapsuleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/SphereConvexHullTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/SphereConvexHullTester.cs
@@ -8,14 +8,14 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct SphereConvexHullTester : IPairTester<SphereWide, ConvexHullWide, Convex1ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
-        public void Test(ref SphereWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref SphereWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             Matrix3x3Wide.CreateFromQuaternion(orientationB, out var hullOrientation);
             Matrix3x3Wide.TransformByTransposedWithoutOverlap(offsetB, hullOrientation, out var localOffsetB);
@@ -45,7 +45,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifold.ContactExists = Vector.GreaterThanOrEqual(manifold.Depth, -speculativeMargin);
         }
 
-        public void Test(ref SphereWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/SphereCylinderTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/SphereCylinderTester.cs
@@ -8,9 +8,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct SphereCylinderTester : IPairTester<SphereWide, CylinderWide, Convex1ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
-        public void Test(ref SphereWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
@@ -37,7 +37,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(ref SphereWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             Matrix3x3Wide.CreateFromQuaternion(orientationB, out var orientationMatrixB);
             ComputeSphereToClosest(b, offsetB, orientationMatrixB, 
@@ -72,7 +72,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifold.ContactExists = Vector.GreaterThanOrEqual(manifold.Depth, -speculativeMargin);
         }
 
-        public void Test(ref SphereWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/SpherePairTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/SpherePairTester.cs
@@ -9,20 +9,20 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
     //Individual pair testers are designed to be used outside of the narrow phase. They need to be usable for queries and such, so all necessary data must be gathered externally.
     public struct SpherePairTester : IPairTester<SphereWide, SphereWide, Convex1ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
-        public void Test(ref SphereWide a, ref SphereWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref SphereWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref SphereWide a, ref SphereWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref SphereWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(ref SphereWide a, ref SphereWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref SphereWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             Vector3Wide.Length(offsetB, out var centerDistance);
             //Note the negative 1. By convention, the normal points from B to A.

--- a/BepuPhysics/CollisionDetection/CollisionTasks/SphereTriangleTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/SphereTriangleTester.cs
@@ -9,9 +9,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
     //Individual pair testers are designed to be used outside of the narrow phase. They need to be usable for queries and such, so all necessary data must be gathered externally.
     public struct SphereTriangleTester : IPairTester<SphereWide, TriangleWide, Convex1ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
-        public void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB,
+        public static void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB,
             int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
@@ -26,7 +26,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount,
+        public static void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount,
             out Convex1ContactManifoldWide manifold)
         {
             Unsafe.SkipInit(out manifold);
@@ -120,7 +120,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
                     Vector.GreaterThanOrEqual(manifold.Depth, -speculativeMargin)));
         }
 
-        public void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
+        public static void Test(ref SphereWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex1ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/TriangleConvexHullTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/TriangleConvexHullTester.cs
@@ -11,9 +11,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
     using DepthRefiner = DepthRefiner<ConvexHull, ConvexHullWide, ConvexHullSupportFinder, Triangle, TriangleWide, PretransformedTriangleSupportFinder>;
     public struct TriangleConvexHullTester : IPairTester<TriangleWide, ConvexHullWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
-        public unsafe void Test(ref TriangleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static unsafe void Test(ref TriangleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             Unsafe.SkipInit(out manifold);
             Matrix3x3Wide.CreateFromQuaternion(orientationA, out var triangleOrientation);
@@ -433,12 +433,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifold.FeatureId0 += faceCollisionFlag;
         }
 
-        public void Test(ref TriangleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref TriangleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref TriangleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref TriangleWide a, ref ConvexHullWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/TriangleCylinderTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/TriangleCylinderTester.cs
@@ -39,7 +39,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 
     public struct TriangleCylinderTester : IPairTester<TriangleWide, CylinderWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 16;
+        public static int BatchSize => 16;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void TryAddInteriorPoint(in Vector2Wide point, in Vector<int> featureId,
@@ -99,7 +99,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Test(
+        public static unsafe void Test(
             ref TriangleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex4ContactManifoldWide manifold)
@@ -594,12 +594,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
         }
 
 
-        public void Test(ref TriangleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref TriangleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref TriangleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref TriangleWide a, ref CylinderWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/CollisionTasks/TrianglePairTester.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/TrianglePairTester.cs
@@ -8,7 +8,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public struct TrianglePairTester : IPairTester<TriangleWide, TriangleWide, Convex4ContactManifoldWide>
     {
-        public int BatchSize => 32;
+        public static int BatchSize => 32;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void GetIntervalForNormal(in Vector3Wide a, in Vector3Wide b, in Vector3Wide c, in Vector3Wide normal, out Vector<float> min, out Vector<float> max)
@@ -258,7 +258,7 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 
 
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Test(
+        public static unsafe void Test(
             ref TriangleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin,
             ref Vector3Wide offsetB, ref QuaternionWide orientationA, ref QuaternionWide orientationB, int pairCount,
             out Convex4ContactManifoldWide manifold)
@@ -523,12 +523,12 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             manifoldFeatureId = rawContact.FeatureId;
         }
 
-        public void Test(ref TriangleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref TriangleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, ref QuaternionWide orientationB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }
 
-        public void Test(ref TriangleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
+        public static void Test(ref TriangleWide a, ref TriangleWide b, ref Vector<float> speculativeMargin, ref Vector3Wide offsetB, int pairCount, out Convex4ContactManifoldWide manifold)
         {
             throw new NotImplementedException();
         }

--- a/BepuPhysics/CollisionDetection/ContactConstraintAccessor.cs
+++ b/BepuPhysics/CollisionDetection/ContactConstraintAccessor.cs
@@ -182,7 +182,7 @@ namespace BepuPhysics.CollisionDetection
                     "The layout of nonconvex accumulated impulses seems to have changed; the assumptions of impulse gather/scatter are probably no longer valid.");
             }
             AccumulatedImpulseBundleStrideInBytes = Unsafe.SizeOf<TAccumulatedImpulses>();
-            ConstraintTypeId = default(TConstraintDescription).ConstraintTypeId;
+            ConstraintTypeId = TConstraintDescription.ConstraintTypeId;
         }
         public override void DeterministicallyAdd<TCallbacks>(int typeIndex, NarrowPhase<TCallbacks>.OverlapWorker[] overlapWorkers,
             ref QuickList<NarrowPhase<TCallbacks>.SortConstraintTarget> constraintsOfType,
@@ -291,7 +291,7 @@ namespace BepuPhysics.CollisionDetection
                 Debug.Assert(manifold.Count == 1, "Nonconvex manifolds should only result in convex constraints when the contact count is 1.");
                 Unsafe.SkipInit(out ConstraintCache constraintCache);
                 Unsafe.SkipInit(out TConstraintDescription description);
-                CopyContactData(ref manifold, ref constraintCache, ref description.GetFirstContact(ref description));
+                CopyContactData(ref manifold, ref constraintCache, ref TConstraintDescription.GetFirstContact(ref description));
                 description.CopyManifoldWideProperties(ref manifold.Contact0.Normal, ref material);
                 UpdateConstraint(narrowPhase, manifoldTypeAsConstraintType, workerIndex, ref pair, ref constraintCache, manifold.Count, ref description, bodyHandles);
             }
@@ -349,7 +349,7 @@ namespace BepuPhysics.CollisionDetection
                 Debug.Assert(manifold.Count == 1, "Nonconvex manifolds should only result in convex constraints when the contact count is 1.");
                 Unsafe.SkipInit(out ConstraintCache constraintCache);
                 Unsafe.SkipInit(out TConstraintDescription description);
-                CopyContactData(ref manifold, ref constraintCache, ref description.GetFirstContact(ref description));
+                CopyContactData(ref manifold, ref constraintCache, ref TConstraintDescription.GetFirstContact(ref description));
                 description.CopyManifoldWideProperties(ref manifold.OffsetB, ref manifold.Contact0.Normal, ref material);
                 UpdateConstraint(narrowPhase, manifoldTypeAsConstraintType, workerIndex, ref pair, ref constraintCache, manifold.Count, ref description, bodyHandles);
             }
@@ -406,7 +406,7 @@ namespace BepuPhysics.CollisionDetection
             ref var manifold = ref Unsafe.As<TContactManifold, NonconvexContactManifold>(ref manifoldPointer);
             Unsafe.SkipInit(out ConstraintCache constraintCache);
             Unsafe.SkipInit(out TConstraintDescription description);
-            CopyContactData(ref manifold, ref constraintCache, ref description.GetFirstContact(ref description));
+            CopyContactData(ref manifold, ref constraintCache, ref TConstraintDescription.GetFirstContact(ref description));
             description.CopyManifoldWideProperties(ref material);
             UpdateConstraint(narrowPhase, manifoldTypeAsConstraintType, workerIndex, ref pair, ref constraintCache, manifold.Count, ref description, bodyHandles);
         }
@@ -452,7 +452,7 @@ namespace BepuPhysics.CollisionDetection
             ref var manifold = ref Unsafe.As<TContactManifold, NonconvexContactManifold>(ref manifoldPointer);
             Unsafe.SkipInit(out ConstraintCache constraintCache);
             Unsafe.SkipInit(out TConstraintDescription description);
-            CopyContactData(ref manifold, ref constraintCache, ref description.GetFirstContact(ref description));
+            CopyContactData(ref manifold, ref constraintCache, ref TConstraintDescription.GetFirstContact(ref description));
             description.CopyManifoldWideProperties(ref manifold.OffsetB, ref material);
             UpdateConstraint(narrowPhase, manifoldTypeAsConstraintType, workerIndex, ref pair, ref constraintCache, manifold.Count, ref description, bodyHandles);
         }

--- a/BepuPhysics/CollisionDetection/NarrowPhasePendingConstraintAdds.cs
+++ b/BepuPhysics/CollisionDetection/NarrowPhasePendingConstraintAdds.cs
@@ -125,7 +125,7 @@ namespace BepuPhysics.CollisionDetection
                 Span<int> encodedBodyIndices = stackalloc int[handles.Length];
                 simulation.Solver.GetBlockingBodyHandles(handles, ref blockingBodyHandles, encodedBodyIndices);
                 while (!simulation.Solver.TryAllocateInBatch(
-                    default(TDescription).ConstraintTypeId, batchIndex,
+                    TDescription.ConstraintTypeId, batchIndex,
                     blockingBodyHandles, encodedBodyIndices, out constraintHandle, out reference))
                 {
                     //If a batch index failed, just try the next one. This is guaranteed to eventually work.

--- a/BepuPhysics/CollisionDetection/SweepTaskRegistry.cs
+++ b/BepuPhysics/CollisionDetection/SweepTaskRegistry.cs
@@ -182,7 +182,7 @@ namespace BepuPhysics.CollisionDetection
             where TShapeA : unmanaged, IShape
             where TShapeB : unmanaged, IShape
         {
-            return GetTask(default(TShapeA).TypeId, default(TShapeB).TypeId);
+            return GetTask(TShapeA.TypeId, TShapeB.TypeId);
         }
     }
 }

--- a/BepuPhysics/CollisionDetection/SweepTasks/CompoundHomogeneousCompoundSweepTask.cs
+++ b/BepuPhysics/CollisionDetection/SweepTasks/CompoundHomogeneousCompoundSweepTask.cs
@@ -15,8 +15,8 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     {
         public CompoundHomogeneousCompoundSweepTask()
         {
-            ShapeTypeIndexA = default(TCompoundA).TypeId;
-            ShapeTypeIndexB = default(TCompoundB).TypeId;
+            ShapeTypeIndexA = TCompoundA.TypeId;
+            ShapeTypeIndexB = TCompoundB.TypeId;
         }
 
         protected unsafe override bool PreorderedTypeSweep<TSweepFilter>(
@@ -26,13 +26,12 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
             bool flipRequired, ref TSweepFilter filter, Shapes shapes, SweepTaskRegistry sweepTasks, BufferPool pool, out float t0, out float t1, out Vector3 hitLocation, out Vector3 hitNormal)
         {
             ref var compoundB = ref Unsafe.AsRef<TCompoundB>(shapeDataB);
-            TOverlapFinder overlapFinder = default;
             t0 = float.MaxValue;
             t1 = float.MaxValue;
             hitLocation = new Vector3();
             hitNormal = new Vector3();
             ref var compoundA = ref Unsafe.AsRef<TCompoundA>(shapeDataA);
-            overlapFinder.FindOverlaps(ref compoundA, orientationA, velocityA, ref compoundB, offsetB, orientationB, velocityB, maximumT, shapes, pool, out var overlaps);
+            TOverlapFinder.FindOverlaps(ref compoundA, orientationA, velocityA, ref compoundB, offsetB, orientationB, velocityB, maximumT, shapes, pool, out var overlaps);
             for (int i = 0; i < overlaps.ChildCount; ++i)
             {
                 ref var childOverlaps = ref overlaps.GetOverlapsForChild(i);

--- a/BepuPhysics/CollisionDetection/SweepTasks/CompoundPairSweepOverlapFinder.cs
+++ b/BepuPhysics/CollisionDetection/SweepTasks/CompoundPairSweepOverlapFinder.cs
@@ -9,7 +9,7 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     //At the moment, this is basically an unused abstraction. But, if you wanted, this allows you to use a special cased overlap finder in certain cases.
     public interface ICompoundPairSweepOverlapFinder<TCompoundA, TCompoundB> where TCompoundA : struct, ICompoundShape where TCompoundB : struct, IBoundsQueryableCompound
     {
-        unsafe void FindOverlaps(ref TCompoundA compoundA, Quaternion orientationA, in BodyVelocity velocityA,
+        static abstract void FindOverlaps(ref TCompoundA compoundA, Quaternion orientationA, in BodyVelocity velocityA,
               ref TCompoundB compoundB, Vector3 offsetB, Quaternion orientationB, in BodyVelocity velocityB, float maximumT,
               Shapes shapes, BufferPool pool, out CompoundPairSweepOverlaps overlaps);
     }
@@ -18,7 +18,7 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
         where TCompoundA : struct, ICompoundShape
         where TCompoundB : struct, IBoundsQueryableCompound
     {
-        public unsafe void FindOverlaps(
+        public static unsafe void FindOverlaps(
             ref TCompoundA compoundA, Quaternion orientationA, in BodyVelocity velocityA,
             ref TCompoundB compoundB, Vector3 offsetB, Quaternion orientationB, in BodyVelocity velocityB, float maximumT,
             Shapes shapes, BufferPool pool, out CompoundPairSweepOverlaps overlaps)

--- a/BepuPhysics/CollisionDetection/SweepTasks/CompoundPairSweepTask.cs
+++ b/BepuPhysics/CollisionDetection/SweepTasks/CompoundPairSweepTask.cs
@@ -13,8 +13,8 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     {
         public CompoundPairSweepTask()
         {
-            ShapeTypeIndexA = default(TCompoundA).TypeId;
-            ShapeTypeIndexB = default(TCompoundB).TypeId;
+            ShapeTypeIndexA = TCompoundA.TypeId;
+            ShapeTypeIndexB = TCompoundB.TypeId;
         }
 
         protected override unsafe bool PreorderedTypeSweep<TSweepFilter>(
@@ -29,7 +29,7 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
             t1 = float.MaxValue;
             hitLocation = new Vector3();
             hitNormal = new Vector3();
-            default(TOverlapFinder).FindOverlaps(
+            TOverlapFinder.FindOverlaps(
                 ref a, orientationA, velocityA,
                 ref b, offsetB, orientationB, velocityB, maximumT, shapes, pool, out var overlaps);
             for (int i = 0; i < overlaps.ChildCount; ++i)

--- a/BepuPhysics/CollisionDetection/SweepTasks/ConvexCompoundSweepOverlapFinder.cs
+++ b/BepuPhysics/CollisionDetection/SweepTasks/ConvexCompoundSweepOverlapFinder.cs
@@ -12,7 +12,7 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     //At the moment, this is basically an unused abstraction. But, if you wanted, this allows you to use a special cased overlap finder in certain cases.
     public interface IConvexCompoundSweepOverlapFinder<TShapeA, TCompoundB> where TShapeA : struct, IConvexShape where TCompoundB : struct, IBoundsQueryableCompound
     {
-        unsafe void FindOverlaps(ref TShapeA shapeA, Quaternion orientationA, in BodyVelocity velocityA,
+        static abstract void FindOverlaps(ref TShapeA shapeA, Quaternion orientationA, in BodyVelocity velocityA,
               ref TCompoundB compoundB, Vector3 offsetB, Quaternion orientationB, in BodyVelocity velocityB, float maximumT,
               Shapes shapes, BufferPool pool, out ChildOverlapsCollection overlaps);
     }
@@ -20,7 +20,7 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     public struct ConvexCompoundSweepOverlapFinder<TShapeA, TCompoundB> : IConvexCompoundSweepOverlapFinder<TShapeA, TCompoundB>
         where TShapeA : struct, IConvexShape where TCompoundB : struct, IBoundsQueryableCompound
     {
-        public unsafe void FindOverlaps(ref TShapeA shapeA, Quaternion orientationA, in BodyVelocity velocityA,
+        public static unsafe void FindOverlaps(ref TShapeA shapeA, Quaternion orientationA, in BodyVelocity velocityA,
             ref TCompoundB compoundB, Vector3 offsetB, Quaternion orientationB, in BodyVelocity velocityB, float maximumT,
             Shapes shapes, BufferPool pool, out ChildOverlapsCollection overlaps)
         {

--- a/BepuPhysics/CollisionDetection/SweepTasks/ConvexCompoundSweepTask.cs
+++ b/BepuPhysics/CollisionDetection/SweepTasks/ConvexCompoundSweepTask.cs
@@ -14,8 +14,8 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     {
         public ConvexCompoundSweepTask()
         {
-            ShapeTypeIndexA = default(TShapeA).TypeId;
-            ShapeTypeIndexB = default(TCompound).TypeId;
+            ShapeTypeIndexA = TShapeA.TypeId;
+            ShapeTypeIndexB = TCompound.TypeId;
         }
 
         protected override unsafe bool PreorderedTypeSweep<TSweepFilter>(
@@ -30,7 +30,7 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
             t1 = float.MaxValue;
             hitLocation = new Vector3();
             hitNormal = new Vector3();
-            default(TOverlapFinder).FindOverlaps(ref convex, orientationA, velocityA, ref compound, offsetB, orientationB, velocityB, maximumT, shapes, pool, out var overlaps);
+            TOverlapFinder.FindOverlaps(ref convex, orientationA, velocityA, ref compound, offsetB, orientationB, velocityB, maximumT, shapes, pool, out var overlaps);
             for (int i = 0; i < overlaps.Count; ++i)
             {
                 var compoundChildIndex = overlaps.Overlaps[i];
@@ -39,9 +39,9 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
                     ref var child = ref compound.GetChild(compoundChildIndex);
                     var childType = child.ShapeIndex.Type;
                     shapes[childType].GetShapeData(child.ShapeIndex.Index, out var childShapeData, out _);
-                    var task = sweepTasks.GetTask(convex.TypeId, childType);
+                    var task = sweepTasks.GetTask(TShapeA.TypeId, childType);
                     if (task != null && task.Sweep(
-                        shapeDataA, convex.TypeId, new RigidPose() { Orientation = Quaternion.Identity }, orientationA, velocityA,
+                        shapeDataA, TShapeA.TypeId, new RigidPose() { Orientation = Quaternion.Identity }, orientationA, velocityA,
                         childShapeData, childType, CompoundChild.AsPose(ref child), offsetB, orientationB, velocityB,
                         maximumT, minimumProgression, convergenceThreshold, maximumIterationCount,
                         out var t0Candidate, out var t1Candidate, out var hitLocationCandidate, out var hitNormalCandidate))

--- a/BepuPhysics/CollisionDetection/SweepTasks/ConvexHomogeneousCompoundSweepTask.cs
+++ b/BepuPhysics/CollisionDetection/SweepTasks/ConvexHomogeneousCompoundSweepTask.cs
@@ -18,8 +18,8 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     {
         public ConvexHomogeneousCompoundSweepTask()
         {
-            ShapeTypeIndexA = default(TConvex).TypeId;
-            ShapeTypeIndexB = default(TCompound).TypeId;
+            ShapeTypeIndexA = TConvex.TypeId;
+            ShapeTypeIndexB = TCompound.TypeId;
         }
 
 
@@ -34,10 +34,10 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
             t1 = float.MaxValue;
             hitLocation = new Vector3();
             hitNormal = new Vector3();
-            var task = sweepTasks.GetTask(ShapeTypeIndexA, default(TChildType).TypeId);
+            var task = sweepTasks.GetTask(ShapeTypeIndexA, TChildType.TypeId);
             if (task != null)
             {
-                default(TOverlapFinder).FindOverlaps(ref Unsafe.AsRef<TConvex>(shapeDataA), orientationA, velocityA, ref compound, offsetB, orientationB, velocityB, maximumT, shapes, pool, out var overlaps);
+                TOverlapFinder.FindOverlaps(ref Unsafe.AsRef<TConvex>(shapeDataA), orientationA, velocityA, ref compound, offsetB, orientationB, velocityB, maximumT, shapes, pool, out var overlaps);
                 for (int i = 0; i < overlaps.Count; ++i)
                 {
                     var childIndex = overlaps.Overlaps[i];

--- a/BepuPhysics/CollisionDetection/SweepTasks/ConvexSweepTaskCommon.cs
+++ b/BepuPhysics/CollisionDetection/SweepTasks/ConvexSweepTaskCommon.cs
@@ -23,8 +23,8 @@ namespace BepuPhysics.CollisionDetection.SweepTasks
     {
         public ConvexPairSweepTask()
         {
-            ShapeTypeIndexA = default(TShapeA).TypeId;
-            ShapeTypeIndexB = default(TShapeB).TypeId;
+            ShapeTypeIndexA = TShapeA.TypeId;
+            ShapeTypeIndexB = TShapeB.TypeId;
         }
         protected override unsafe bool PreorderedTypeSweep(
             void* shapeDataA, in RigidPose localPoseA, Quaternion orientationA, in BodyVelocity velocityA,

--- a/BepuPhysics/CollisionDetection/WideRayTester.cs
+++ b/BepuPhysics/CollisionDetection/WideRayTester.cs
@@ -33,7 +33,7 @@ namespace BepuPhysics.CollisionDetection
             for (int i = 0; i < raySource.RayCount; i += Vector<float>.Count)
             {
                 var count = raySource.RayCount - i;
-                if (count < wide.MinimumWideRayCount)
+                if (count < TShapeWide.MinimumWideRayCount)
                 {
                     for (int j = 0; j < count; ++j)
                     {

--- a/BepuPhysics/Constraints/AngularAxisGearMotor.cs
+++ b/BepuPhysics/Constraints/AngularAxisGearMotor.cs
@@ -28,7 +28,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -37,8 +37,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(AngularAxisGearMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new AngularAxisGearMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(AngularAxisGearMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new AngularAxisGearMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -51,7 +51,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularAxisGearMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularAxisGearMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<AngularAxisGearMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -78,7 +78,7 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularAxisGearMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularAxisGearMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalAxisA, orientationA, out var axis);
             Vector3Wide.Scale(axis, prestep.VelocityScale, out var jA);
@@ -88,7 +88,7 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularAxisGearMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularAxisGearMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //This is mildly more complex than the AngularAxisMotor:
             //dot(wa, axis) * velocityScale - dot(wb, axis) = 0, so jacobianA is actually axis * velocityScale, not just -axis.
@@ -109,9 +109,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(impulseToVelocityA, negatedImpulseToVelocityB, accumulatedImpulses, ref wsvA.Angular, ref wsvB.Angular);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularAxisGearMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularAxisGearMotorPrestepData prestepData) { }
     }
 
     public class AngularAxisGearMotorTypeProcessor : TwoBodyTypeProcessor<AngularAxisGearMotorPrestepData, Vector<float>, AngularAxisGearMotorFunctions, AccessOnlyAngular, AccessOnlyAngularWithoutPose, AccessOnlyAngular, AccessOnlyAngularWithoutPose>

--- a/BepuPhysics/Constraints/AngularAxisMotor.cs
+++ b/BepuPhysics/Constraints/AngularAxisMotor.cs
@@ -27,7 +27,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -36,8 +36,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(AngularAxisMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new AngularAxisMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(AngularAxisMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new AngularAxisMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -50,7 +50,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularAxisMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularAxisMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<AngularAxisMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -77,7 +77,7 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalAxisA, orientationA, out var axis);
             Symmetric3x3Wide.TransformWithoutOverlap(axis, inertiaA.InverseInertiaTensor, out var jIA);
@@ -86,7 +86,7 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalAxisA, orientationA, out var jA);
             Symmetric3x3Wide.TransformWithoutOverlap(jA, inertiaA.InverseInertiaTensor, out var jIA);
@@ -101,9 +101,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(jIA, jIB, csi, ref wsvA.Angular, ref wsvB.Angular);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularAxisMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularAxisMotorPrestepData prestepData) { }
     }
 
     public class AngularAxisMotorTypeProcessor : TwoBodyTypeProcessor<AngularAxisMotorPrestepData, Vector<float>, AngularAxisMotorFunctions, AccessOnlyAngular, AccessOnlyAngularWithoutPose, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/AngularHinge.cs
+++ b/BepuPhysics/Constraints/AngularHinge.cs
@@ -26,7 +26,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -35,8 +35,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(AngularHingeTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new AngularHingeTypeProcessor();
+        public static Type TypeProcessorType => typeof(AngularHingeTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new AngularHingeTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -51,7 +51,7 @@ namespace BepuPhysics.Constraints
             GetFirst(ref target.SpringSettings.TwiceDampingRatio) = SpringSettings.TwiceDampingRatio;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularHinge description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularHinge description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<AngularHingePrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -131,7 +131,7 @@ namespace BepuPhysics.Constraints
             Matrix3x3Wide.TransformWithoutOverlap(localAY, orientationMatrixA, out jacobianA.Y);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularHingePrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularHingePrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(prestep.LocalHingeAxisA, orientationA, out _, out var jacobianA);
             Symmetric3x3Wide.MultiplyWithoutOverlap(jacobianA, inertiaA.InverseInertiaTensor, out var impulseToVelocityA);
@@ -139,7 +139,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(impulseToVelocityA, negatedImpulseToVelocityB, accumulatedImpulses, ref wsvA.Angular, ref wsvB.Angular);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularHingePrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularHingePrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //Note that we build the tangents in local space first to avoid inconsistencies.
             ComputeJacobians(prestep.LocalHingeAxisA, orientationA, out var hingeAxisA, out var jacobianA);
@@ -218,9 +218,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(impulseToVelocityA, negatedImpulseToVelocityB, csi, ref wsvA.Angular, ref wsvB.Angular);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularHingePrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularHingePrestepData prestepData) { }
     }
 
     public class AngularHingeTypeProcessor : TwoBodyTypeProcessor<AngularHingePrestepData, Vector2Wide, AngularHingeFunctions, AccessOnlyAngular, AccessOnlyAngularWithoutPose, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/AngularMotor.cs
+++ b/BepuPhysics/Constraints/AngularMotor.cs
@@ -22,7 +22,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -31,8 +31,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(AngularMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new AngularMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(AngularMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new AngularMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -43,7 +43,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<AngularMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -60,12 +60,12 @@ namespace BepuPhysics.Constraints
 
     public struct AngularMotorFunctions : ITwoBodyConstraintFunctions<AngularMotorPrestepData, Vector3Wide>
     {
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             AngularServoFunctions.ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, inertiaA.InverseInertiaTensor, inertiaB.InverseInertiaTensor, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //Jacobians are just the identity matrix.
             MotorSettingsWide.ComputeSoftness(prestep.Settings, dt, out var effectiveMassCFMScale, out var softnessImpulseScale, out var maximumImpulse);
@@ -88,9 +88,9 @@ namespace BepuPhysics.Constraints
             AngularServoFunctions.ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, inertiaA.InverseInertiaTensor, inertiaB.InverseInertiaTensor, csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularMotorPrestepData prestepData) { }
     }
 
     public class AngularMotorTypeProcessor : TwoBodyTypeProcessor<AngularMotorPrestepData, Vector3Wide, AngularMotorFunctions, AccessOnlyAngularWithoutPose, AccessOnlyAngularWithoutPose, AccessOnlyAngular, AccessOnlyAngularWithoutPose>

--- a/BepuPhysics/Constraints/AngularServo.cs
+++ b/BepuPhysics/Constraints/AngularServo.cs
@@ -26,7 +26,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public ServoSettings ServoSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -35,8 +35,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(AngularServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new AngularServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(AngularServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new AngularServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -49,7 +49,7 @@ namespace BepuPhysics.Constraints
             ServoSettingsWide.WriteFirst(ServoSettings, ref target.ServoSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<AngularServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -98,12 +98,12 @@ namespace BepuPhysics.Constraints
         //}
 
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, inertiaA.InverseInertiaTensor, inertiaB.InverseInertiaTensor, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //Jacobians are just I and -I.
             QuaternionWide.ConcatenateWithoutOverlap(prestep.TargetRelativeRotationLocalA, orientationA, out var targetOrientationB);
@@ -132,9 +132,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, inertiaA.InverseInertiaTensor, inertiaB.InverseInertiaTensor, csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularServoPrestepData prestepData) { }
     }
 
     public class AngularServoTypeProcessor : TwoBodyTypeProcessor<AngularServoPrestepData, Vector3Wide, AngularServoFunctions, AccessOnlyAngularWithoutPose, AccessOnlyAngularWithoutPose, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/AngularSwivelHinge.cs
+++ b/BepuPhysics/Constraints/AngularSwivelHinge.cs
@@ -26,7 +26,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -35,8 +35,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(AngularSwivelHingeTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new AngularSwivelHingeTypeProcessor();
+        public static Type TypeProcessorType => typeof(AngularSwivelHingeTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new AngularSwivelHingeTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -51,7 +51,7 @@ namespace BepuPhysics.Constraints
             GetFirst(ref target.SpringSettings.TwiceDampingRatio) = SpringSettings.TwiceDampingRatio;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularSwivelHinge description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AngularSwivelHinge description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<AngularSwivelHingePrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -94,7 +94,7 @@ namespace BepuPhysics.Constraints
             Vector3Wide.ConditionalSelect(useFallback, fallbackJacobian, jacobianA, out jacobianA);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularSwivelHingePrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref AngularSwivelHingePrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(prestep.LocalSwivelAxisA, prestep.LocalHingeAxisB, orientationA, orientationB, out _, out _, out var jacobianA);
             Symmetric3x3Wide.TransformWithoutOverlap(jacobianA, inertiaA.InverseInertiaTensor, out var impulseToVelocityA);
@@ -102,7 +102,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(impulseToVelocityA, negatedImpulseToVelocityB, accumulatedImpulses, ref wsvA.Angular, ref wsvB.Angular);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularSwivelHingePrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref AngularSwivelHingePrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //The swivel hinge attempts to keep an axis on body A separated 90 degrees from an axis on body B. In other words, this is the same as a hinge joint, but with one fewer DOF.
             //C = dot(swivelA, hingeB) = 0
@@ -143,9 +143,9 @@ namespace BepuPhysics.Constraints
 
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularSwivelHingePrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref AngularSwivelHingePrestepData prestepData) { }
     }
 
     public class AngularSwivelHingeTypeProcessor : TwoBodyTypeProcessor<AngularSwivelHingePrestepData, Vector<float>, AngularSwivelHingeFunctions, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/AreaConstraint.cs
+++ b/BepuPhysics/Constraints/AreaConstraint.cs
@@ -37,7 +37,7 @@ namespace BepuPhysics.Constraints
             SpringSettings = springSettings;
         }
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -46,8 +46,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(AreaConstraintTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new AreaConstraintTypeProcessor();
+        public static Type TypeProcessorType => typeof(AreaConstraintTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new AreaConstraintTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -59,7 +59,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AreaConstraint description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out AreaConstraint description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<AreaConstraintPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -121,7 +121,7 @@ namespace BepuPhysics.Constraints
             Vector3Wide.Add(jacobianB, jacobianC, out negatedJacobianA);
         }
 
-        public void WarmStart(
+        public static void WarmStart(
             in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA,
             in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, 
             in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC, 
@@ -131,7 +131,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(inertiaA.InverseMass, inertiaB.InverseMass, inertiaC.InverseMass, negatedJacobianA, jacobianB, jacobianC, accumulatedImpulses, ref wsvA, ref wsvB, ref wsvC);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC, float dt, float inverseDt, ref AreaConstraintPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB, ref BodyVelocityWide wsvC)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC, float dt, float inverseDt, ref AreaConstraintPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB, ref BodyVelocityWide wsvC)
         {
             ComputeJacobian(positionA, positionB, positionC, out var normalLength, out var negatedJacobianA, out var jacobianB, out var jacobianC);
 
@@ -167,9 +167,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(inertiaA.InverseMass, inertiaB.InverseMass, inertiaC.InverseMass, negatedJacobianA, jacobianB, jacobianC, csi, ref wsvA, ref wsvB, ref wsvC);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, in BodyVelocityWide wsvC, ref AreaConstraintPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, in BodyVelocityWide wsvC, ref AreaConstraintPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/Constraints/BallSocket.cs
+++ b/BepuPhysics/Constraints/BallSocket.cs
@@ -26,7 +26,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -35,8 +35,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(BallSocketTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new BallSocketTypeProcessor();
+        public static Type TypeProcessorType => typeof(BallSocketTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new BallSocketTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -48,7 +48,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out BallSocket description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out BallSocket description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<BallSocketPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -66,7 +66,7 @@ namespace BepuPhysics.Constraints
     }
     public struct BallSocketFunctions : ITwoBodyConstraintFunctions<BallSocketPrestepData, Vector3Wide>
     {
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
             ref BallSocketPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetA, orientationA, out var offsetA);
@@ -74,7 +74,7 @@ namespace BepuPhysics.Constraints
             BallSocketShared.ApplyImpulse(ref wsvA, ref wsvB, offsetA, offsetB, inertiaA, inertiaB, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
             ref BallSocketPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetA, orientationA, out var offsetA);
@@ -91,9 +91,9 @@ namespace BepuPhysics.Constraints
             BallSocketShared.Solve(ref wsvA, ref wsvB, offsetA, offsetB, biasVelocity, effectiveMass, softnessImpulseScale, ref accumulatedImpulses, inertiaA, inertiaB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref BallSocketPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref BallSocketPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/Constraints/BallSocketMotor.cs
+++ b/BepuPhysics/Constraints/BallSocketMotor.cs
@@ -29,7 +29,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -38,8 +38,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(BallSocketMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new BallSocketMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(BallSocketMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new BallSocketMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -51,7 +51,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out BallSocketMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out BallSocketMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<BallSocketMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -70,13 +70,13 @@ namespace BepuPhysics.Constraints
 
     public struct BallSocketMotorFunctions : ITwoBodyConstraintFunctions<BallSocketMotorPrestepData, Vector3Wide>
     {
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref BallSocketMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref BallSocketMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetB, orientationB, out var targetOffsetB);
             BallSocketShared.ApplyImpulse(ref wsvA, ref wsvB, (positionB - positionA) + targetOffsetB, targetOffsetB, inertiaA, inertiaB, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref BallSocketMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref BallSocketMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetB, orientationB, out var targetOffsetB);
             var offsetA = (positionB - positionA) + targetOffsetB;
@@ -90,9 +90,9 @@ namespace BepuPhysics.Constraints
             BallSocketShared.Solve(ref wsvA, ref wsvB, offsetA, targetOffsetB, biasVelocity, effectiveMass, softnessImpulseScale, maximumImpulse, ref accumulatedImpulses, inertiaA, inertiaB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref BallSocketMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref BallSocketMotorPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/Constraints/BallSocketServo.cs
+++ b/BepuPhysics/Constraints/BallSocketServo.cs
@@ -31,7 +31,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public ServoSettings ServoSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -40,8 +40,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(BallSocketServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new BallSocketServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(BallSocketServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new BallSocketServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -54,7 +54,7 @@ namespace BepuPhysics.Constraints
             ServoSettingsWide.WriteFirst(ServoSettings, ref target.ServoSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out BallSocketServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out BallSocketServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<BallSocketServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -75,14 +75,14 @@ namespace BepuPhysics.Constraints
 
     public struct BallSocketServoFunctions : ITwoBodyConstraintFunctions<BallSocketServoPrestepData, Vector3Wide>
     {
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref BallSocketServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref BallSocketServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetA, orientationA, out var offsetA);
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetB, orientationB, out var offsetB);
             BallSocketShared.ApplyImpulse(ref wsvA, ref wsvB, offsetA, offsetB, inertiaA, inertiaB, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref BallSocketServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref BallSocketServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetA, orientationA, out var offsetA);
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffsetB, orientationB, out var offsetB);
@@ -98,9 +98,9 @@ namespace BepuPhysics.Constraints
             BallSocketShared.Solve(ref wsvA, ref wsvB, offsetA, offsetB, biasVelocity, effectiveMass, softnessImpulseScale, maximumImpulse, ref accumulatedImpulses, inertiaA, inertiaB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref BallSocketServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref BallSocketServoPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/Constraints/CenterDistanceConstraint.cs
+++ b/BepuPhysics/Constraints/CenterDistanceConstraint.cs
@@ -30,7 +30,7 @@ namespace BepuPhysics.Constraints
             SpringSettings = springSettings;
         }
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -39,8 +39,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(CenterDistanceTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new CenterDistanceTypeProcessor();
+        public static Type TypeProcessorType => typeof(CenterDistanceTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new CenterDistanceTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -52,7 +52,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out CenterDistanceConstraint description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out CenterDistanceConstraint description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<CenterDistancePrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -80,7 +80,7 @@ namespace BepuPhysics.Constraints
 
 
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
             ref CenterDistancePrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             var ab = positionB - positionA;
@@ -95,7 +95,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(jacobianA, inertiaA.InverseMass, inertiaB.InverseMass, accumulatedImpulses, ref wsvA, ref wsvB);
         }
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
             ref CenterDistancePrestepData prestep, ref Vector<float> accumulatedImpulse, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //Note that we need the actual length for error calculation.
@@ -123,9 +123,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(jacobianA, inertiaA.InverseMass, inertiaB.InverseMass, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref CenterDistancePrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref CenterDistancePrestepData prestepData) { }
 
     }
 

--- a/BepuPhysics/Constraints/CenterDistanceLimit.cs
+++ b/BepuPhysics/Constraints/CenterDistanceLimit.cs
@@ -35,7 +35,7 @@ namespace BepuPhysics.Constraints
             SpringSettings = springSettings;
         }
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -44,8 +44,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(CenterDistanceLimitTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new CenterDistanceLimitTypeProcessor();
+        public static Type TypeProcessorType => typeof(CenterDistanceLimitTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new CenterDistanceLimitTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -59,7 +59,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out CenterDistanceLimit description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out CenterDistanceLimit description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<CenterDistanceLimitPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -96,14 +96,14 @@ namespace BepuPhysics.Constraints
             jacobianA = Vector3Wide.ConditionalSelect(useMinimum, -jacobianA, jacobianA);
         }
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
             ref CenterDistanceLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(prestep.MinimumDistance, prestep.MaximumDistance, positionA, positionB, out var jacobianA, out _, out _);
             CenterDistanceConstraintFunctions.ApplyImpulse(jacobianA, inertiaA.InverseMass, inertiaB.InverseMass, accumulatedImpulses, ref wsvA, ref wsvB);
         }
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
             ref CenterDistanceLimitPrestepData prestep, ref Vector<float> accumulatedImpulse, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(prestep.MinimumDistance, prestep.MaximumDistance, positionA, positionB, out var jacobianA, out var distance, out var useMinimum);
@@ -122,9 +122,9 @@ namespace BepuPhysics.Constraints
             CenterDistanceConstraintFunctions.ApplyImpulse(jacobianA, inertiaA.InverseMass, inertiaB.InverseMass, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref CenterDistanceLimitPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref CenterDistanceLimitPrestepData prestepData) { }
 
     }
 

--- a/BepuPhysics/Constraints/Contact/ContactConvexCommon.cs
+++ b/BepuPhysics/Constraints/Contact/ContactConvexCommon.cs
@@ -22,34 +22,34 @@ namespace BepuPhysics.Constraints.Contact
 
     public interface IContactPrestep<TPrestep> where TPrestep : struct, IContactPrestep<TPrestep>
     {
-        ref MaterialPropertiesWide GetMaterialProperties(ref TPrestep prestep);
-        int ContactCount { get; }
-        int BodyCount { get; }
+        static abstract ref MaterialPropertiesWide GetMaterialProperties(ref TPrestep prestep);
+        static abstract int ContactCount { get; }
+        static abstract int BodyCount { get; }
     }
 
 
     public interface IConvexContactPrestep<TPrestep> : IContactPrestep<TPrestep> where TPrestep : struct, IConvexContactPrestep<TPrestep>
     {
-        ref Vector3Wide GetNormal(ref TPrestep prestep);
-        ref ConvexContactWide GetContact(ref TPrestep prestep, int index);
+        static abstract ref Vector3Wide GetNormal(ref TPrestep prestep);
+        static abstract ref ConvexContactWide GetContact(ref TPrestep prestep, int index);
 
     }
 
     public interface ITwoBodyConvexContactPrestep<TPrestep> : IConvexContactPrestep<TPrestep> where TPrestep : struct, ITwoBodyConvexContactPrestep<TPrestep>
     {
-        ref Vector3Wide GetOffsetB(ref TPrestep prestep);
+        static abstract ref Vector3Wide GetOffsetB(ref TPrestep prestep);
     }
 
     public interface IContactAccumulatedImpulses<TAccumulatedImpulses> where TAccumulatedImpulses : struct, IContactAccumulatedImpulses<TAccumulatedImpulses>
     {
-        int ContactCount { get; }
+        static abstract int ContactCount { get; }
     }
 
     public interface IConvexContactAccumulatedImpulses<TAccumulatedImpulses> : IContactAccumulatedImpulses<TAccumulatedImpulses> where TAccumulatedImpulses : struct, IConvexContactAccumulatedImpulses<TAccumulatedImpulses>
     {
-        ref Vector2Wide GetTangentFriction(ref TAccumulatedImpulses impulses);
-        ref Vector<float> GetTwistFriction(ref TAccumulatedImpulses impulses);
-        ref Vector<float> GetPenetrationImpulseForContact(ref TAccumulatedImpulses impulses, int index);
+        static abstract ref Vector2Wide GetTangentFriction(ref TAccumulatedImpulses impulses);
+        static abstract ref Vector<float> GetTwistFriction(ref TAccumulatedImpulses impulses);
+        static abstract ref Vector<float> GetPenetrationImpulseForContact(ref TAccumulatedImpulses impulses, int index);
     }
 
 }

--- a/BepuPhysics/Constraints/Contact/ContactConvexTypes.cs
+++ b/BepuPhysics/Constraints/Contact/ContactConvexTypes.cs
@@ -15,23 +15,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector<float> Twist;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector2Wide GetTangentFriction(ref Contact1AccumulatedImpulses impulses)
+        public static ref Vector2Wide GetTangentFriction(ref Contact1AccumulatedImpulses impulses)
         {
             return ref impulses.Tangent;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetTwistFriction(ref Contact1AccumulatedImpulses impulses)
+        public static ref Vector<float> GetTwistFriction(ref Contact1AccumulatedImpulses impulses)
         {
             return ref impulses.Twist;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetPenetrationImpulseForContact(ref Contact1AccumulatedImpulses impulses, int index)
+        public static ref Vector<float> GetPenetrationImpulseForContact(ref Contact1AccumulatedImpulses impulses, int index)
         {
             Debug.Assert(index >= 0 && index < 1);
             return ref Unsafe.Add(ref impulses.Penetration0, index);
         }
-        public int ContactCount => 1;
+        public static int ContactCount => 1;
     }
 
     public struct Contact2AccumulatedImpulses : IConvexContactAccumulatedImpulses<Contact2AccumulatedImpulses>
@@ -42,23 +42,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector<float> Twist;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector2Wide GetTangentFriction(ref Contact2AccumulatedImpulses impulses)
+        public static ref Vector2Wide GetTangentFriction(ref Contact2AccumulatedImpulses impulses)
         {
             return ref impulses.Tangent;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetTwistFriction(ref Contact2AccumulatedImpulses impulses)
+        public static ref Vector<float> GetTwistFriction(ref Contact2AccumulatedImpulses impulses)
         {
             return ref impulses.Twist;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetPenetrationImpulseForContact(ref Contact2AccumulatedImpulses impulses, int index)
+        public static ref Vector<float> GetPenetrationImpulseForContact(ref Contact2AccumulatedImpulses impulses, int index)
         {
             Debug.Assert(index >= 0 && index < 2);
             return ref Unsafe.Add(ref impulses.Penetration0, index);
         }
-        public int ContactCount => 2;
+        public static int ContactCount => 2;
     }
 
     public struct Contact3AccumulatedImpulses : IConvexContactAccumulatedImpulses<Contact3AccumulatedImpulses>
@@ -70,23 +70,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector<float> Twist;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector2Wide GetTangentFriction(ref Contact3AccumulatedImpulses impulses)
+        public static ref Vector2Wide GetTangentFriction(ref Contact3AccumulatedImpulses impulses)
         {
             return ref impulses.Tangent;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetTwistFriction(ref Contact3AccumulatedImpulses impulses)
+        public static ref Vector<float> GetTwistFriction(ref Contact3AccumulatedImpulses impulses)
         {
             return ref impulses.Twist;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetPenetrationImpulseForContact(ref Contact3AccumulatedImpulses impulses, int index)
+        public static ref Vector<float> GetPenetrationImpulseForContact(ref Contact3AccumulatedImpulses impulses, int index)
         {
             Debug.Assert(index >= 0 && index < 3);
             return ref Unsafe.Add(ref impulses.Penetration0, index);
         }
-        public int ContactCount => 3;
+        public static int ContactCount => 3;
     }
 
     public struct Contact4AccumulatedImpulses : IConvexContactAccumulatedImpulses<Contact4AccumulatedImpulses>
@@ -99,23 +99,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector<float> Twist;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector2Wide GetTangentFriction(ref Contact4AccumulatedImpulses impulses)
+        public static ref Vector2Wide GetTangentFriction(ref Contact4AccumulatedImpulses impulses)
         {
             return ref impulses.Tangent;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetTwistFriction(ref Contact4AccumulatedImpulses impulses)
+        public static ref Vector<float> GetTwistFriction(ref Contact4AccumulatedImpulses impulses)
         {
             return ref impulses.Twist;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetPenetrationImpulseForContact(ref Contact4AccumulatedImpulses impulses, int index)
+        public static ref Vector<float> GetPenetrationImpulseForContact(ref Contact4AccumulatedImpulses impulses, int index)
         {
             Debug.Assert(index >= 0 && index < 4);
             return ref Unsafe.Add(ref impulses.Penetration0, index);
         }
-        public int ContactCount => 4;
+        public static int ContactCount => 4;
     }
 
     internal static class FrictionHelpers
@@ -217,7 +217,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact1OneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact1OneBody description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact1OneBodyPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -239,19 +239,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact1OneBody description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact1OneBody description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact1OneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact1OneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact1OneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact1OneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact1OneBodyTypeProcessor();
 
     }
 
@@ -265,23 +265,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 1;
-        public readonly int ContactCount => 1;
+        public static int BodyCount => 1;
+        public static int ContactCount => 1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact1OneBodyPrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact1OneBodyPrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact1OneBodyPrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact1OneBodyPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact1OneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact1OneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
@@ -291,16 +291,16 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact1OneBodyFunctions : IOneBodyConstraintFunctions<Contact1OneBodyPrestepData, Contact1AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact1OneBodyPrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact1OneBodyPrestepData prestep)
         {
             PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.Normal, velocityA, ref prestep.Contact0.Depth);
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact1OneBodyPrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact1OneBodyPrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             TangentFrictionOneBody.WarmStart(x, z, prestep.Contact0.OffsetA, inertiaA, accumulatedImpulses.Tangent, ref wsvA);
@@ -309,7 +309,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact1OneBodyPrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact1OneBodyPrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.
@@ -363,7 +363,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2OneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2OneBody description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact2OneBodyPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -387,19 +387,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact2OneBody description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact2OneBody description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact2OneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact2OneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact2OneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact2OneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact2OneBodyTypeProcessor();
 
     }
 
@@ -414,23 +414,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 1;
-        public readonly int ContactCount => 2;
+        public static int BodyCount => 1;
+        public static int ContactCount => 2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact2OneBodyPrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact2OneBodyPrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact2OneBodyPrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact2OneBodyPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact2OneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact2OneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
@@ -440,17 +440,17 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact2OneBodyFunctions : IOneBodyConstraintFunctions<Contact2OneBodyPrestepData, Contact2AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact2OneBodyPrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact2OneBodyPrestepData prestep)
         {
             PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.Normal, velocityA, ref prestep.Contact0.Depth);
             PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestep.Contact1.OffsetA, prestep.Normal, velocityA, ref prestep.Contact1.Depth);
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact2OneBodyPrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact2OneBodyPrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             FrictionHelpers.ComputeFrictionCenter(prestep.Contact0.OffsetA, prestep.Contact1.OffsetA, prestep.Contact0.Depth, prestep.Contact1.Depth, out var offsetToManifoldCenterA);
@@ -461,7 +461,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact2OneBodyPrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact2OneBodyPrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.
@@ -521,7 +521,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3OneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3OneBody description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact3OneBodyPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -547,19 +547,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact3OneBody description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact3OneBody description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact3OneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact3OneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact3OneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact3OneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact3OneBodyTypeProcessor();
 
     }
 
@@ -575,23 +575,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 1;
-        public readonly int ContactCount => 3;
+        public static int BodyCount => 1;
+        public static int ContactCount => 3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact3OneBodyPrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact3OneBodyPrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact3OneBodyPrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact3OneBodyPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact3OneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact3OneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
@@ -601,10 +601,10 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact3OneBodyFunctions : IOneBodyConstraintFunctions<Contact3OneBodyPrestepData, Contact3AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact3OneBodyPrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact3OneBodyPrestepData prestep)
         {
             PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.Normal, velocityA, ref prestep.Contact0.Depth);
             PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestep.Contact1.OffsetA, prestep.Normal, velocityA, ref prestep.Contact1.Depth);
@@ -612,7 +612,7 @@ namespace BepuPhysics.Constraints.Contact
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact3OneBodyPrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact3OneBodyPrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             FrictionHelpers.ComputeFrictionCenter(prestep.Contact0.OffsetA, prestep.Contact1.OffsetA, prestep.Contact2.OffsetA, prestep.Contact0.Depth, prestep.Contact1.Depth, prestep.Contact2.Depth, out var offsetToManifoldCenterA);
@@ -624,7 +624,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact3OneBodyPrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact3OneBodyPrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.
@@ -689,7 +689,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4OneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4OneBody description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact4OneBodyPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -717,19 +717,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact4OneBody description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact4OneBody description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact4OneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact4OneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact4OneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact4OneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact4OneBodyTypeProcessor();
 
     }
 
@@ -746,23 +746,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 1;
-        public readonly int ContactCount => 4;
+        public static int BodyCount => 1;
+        public static int ContactCount => 4;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact4OneBodyPrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact4OneBodyPrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact4OneBodyPrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact4OneBodyPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact4OneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact4OneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
@@ -772,10 +772,10 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact4OneBodyFunctions : IOneBodyConstraintFunctions<Contact4OneBodyPrestepData, Contact4AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact4OneBodyPrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref Contact4OneBodyPrestepData prestep)
         {
             PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.Normal, velocityA, ref prestep.Contact0.Depth);
             PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestep.Contact1.OffsetA, prestep.Normal, velocityA, ref prestep.Contact1.Depth);
@@ -784,7 +784,7 @@ namespace BepuPhysics.Constraints.Contact
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact4OneBodyPrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref Contact4OneBodyPrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             FrictionHelpers.ComputeFrictionCenter(prestep.Contact0.OffsetA, prestep.Contact1.OffsetA, prestep.Contact2.OffsetA, prestep.Contact3.OffsetA, prestep.Contact0.Depth, prestep.Contact1.Depth, prestep.Contact2.Depth, prestep.Contact3.Depth, out var offsetToManifoldCenterA);
@@ -797,7 +797,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact4OneBodyPrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref Contact4OneBodyPrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.
@@ -857,7 +857,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact1 description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact1 description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact1PrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -882,19 +882,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact1 description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact1 description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact1TypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact1TypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact1TypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact1TypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact1TypeProcessor();
 
     }
 
@@ -909,29 +909,29 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 2;
-        public readonly int ContactCount => 1;
+        public static int BodyCount => 2;
+        public static int ContactCount => 1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact1PrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact1PrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact1PrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact1PrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact1PrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact1PrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact1PrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact1PrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
@@ -940,16 +940,16 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact1Functions : ITwoBodyConstraintFunctions<Contact1PrestepData, Contact1AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact1PrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact1PrestepData prestep)
         {
             PenetrationLimit.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.OffsetB, prestep.Normal, velocityA, velocityB, ref prestep.Contact0.Depth);
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact1PrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact1PrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             Vector3Wide.Subtract(prestep.Contact0.OffsetA, prestep.OffsetB, out var offsetToManifoldCenterB);
@@ -959,7 +959,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact1PrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact1PrestepData prestep, ref Contact1AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.
@@ -1016,7 +1016,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2 description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2 description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact2PrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -1043,19 +1043,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact2 description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact2 description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact2TypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact2TypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact2TypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact2TypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact2TypeProcessor();
 
     }
 
@@ -1071,29 +1071,29 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 2;
-        public readonly int ContactCount => 2;
+        public static int BodyCount => 2;
+        public static int ContactCount => 2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact2PrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact2PrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact2PrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact2PrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact2PrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact2PrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact2PrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact2PrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
@@ -1102,17 +1102,17 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact2Functions : ITwoBodyConstraintFunctions<Contact2PrestepData, Contact2AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact2PrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact2PrestepData prestep)
         {
             PenetrationLimit.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.OffsetB, prestep.Normal, velocityA, velocityB, ref prestep.Contact0.Depth);
             PenetrationLimit.UpdatePenetrationDepth(dt, prestep.Contact1.OffsetA, prestep.OffsetB, prestep.Normal, velocityA, velocityB, ref prestep.Contact1.Depth);
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact2PrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact2PrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             FrictionHelpers.ComputeFrictionCenter(prestep.Contact0.OffsetA, prestep.Contact1.OffsetA, prestep.Contact0.Depth, prestep.Contact1.Depth, out var offsetToManifoldCenterA);
@@ -1124,7 +1124,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact2PrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact2PrestepData prestep, ref Contact2AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.
@@ -1187,7 +1187,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3 description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3 description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact3PrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -1216,19 +1216,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact3 description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact3 description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact3TypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact3TypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact3TypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact3TypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact3TypeProcessor();
 
     }
 
@@ -1245,29 +1245,29 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 2;
-        public readonly int ContactCount => 3;
+        public static int BodyCount => 2;
+        public static int ContactCount => 3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact3PrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact3PrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact3PrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact3PrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact3PrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact3PrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact3PrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact3PrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
@@ -1276,10 +1276,10 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact3Functions : ITwoBodyConstraintFunctions<Contact3PrestepData, Contact3AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact3PrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact3PrestepData prestep)
         {
             PenetrationLimit.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.OffsetB, prestep.Normal, velocityA, velocityB, ref prestep.Contact0.Depth);
             PenetrationLimit.UpdatePenetrationDepth(dt, prestep.Contact1.OffsetA, prestep.OffsetB, prestep.Normal, velocityA, velocityB, ref prestep.Contact1.Depth);
@@ -1287,7 +1287,7 @@ namespace BepuPhysics.Constraints.Contact
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact3PrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact3PrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             FrictionHelpers.ComputeFrictionCenter(prestep.Contact0.OffsetA, prestep.Contact1.OffsetA, prestep.Contact2.OffsetA, prestep.Contact0.Depth, prestep.Contact1.Depth, prestep.Contact2.Depth, out var offsetToManifoldCenterA);
@@ -1300,7 +1300,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact3PrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact3PrestepData prestep, ref Contact3AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.
@@ -1368,7 +1368,7 @@ namespace BepuPhysics.Constraints.Contact
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4 description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4 description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact4PrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -1399,19 +1399,19 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact4 description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact4 description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact4TypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact4TypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact4TypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact4TypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact4TypeProcessor();
 
     }
 
@@ -1429,29 +1429,29 @@ namespace BepuPhysics.Constraints.Contact
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => 2;
-        public readonly int ContactCount => 4;
+        public static int BodyCount => 2;
+        public static int ContactCount => 4;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact4PrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact4PrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact4PrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact4PrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact4PrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact4PrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact4PrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact4PrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
@@ -1460,10 +1460,10 @@ namespace BepuPhysics.Constraints.Contact
 
     public struct Contact4Functions : ITwoBodyConstraintFunctions<Contact4PrestepData, Contact4AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact4PrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref Contact4PrestepData prestep)
         {
             PenetrationLimit.UpdatePenetrationDepth(dt, prestep.Contact0.OffsetA, prestep.OffsetB, prestep.Normal, velocityA, velocityB, ref prestep.Contact0.Depth);
             PenetrationLimit.UpdatePenetrationDepth(dt, prestep.Contact1.OffsetA, prestep.OffsetB, prestep.Normal, velocityA, velocityB, ref prestep.Contact1.Depth);
@@ -1472,7 +1472,7 @@ namespace BepuPhysics.Constraints.Contact
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact4PrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref Contact4PrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
             FrictionHelpers.ComputeFrictionCenter(prestep.Contact0.OffsetA, prestep.Contact1.OffsetA, prestep.Contact2.OffsetA, prestep.Contact3.OffsetA, prestep.Contact0.Depth, prestep.Contact1.Depth, prestep.Contact2.Depth, prestep.Contact3.Depth, out var offsetToManifoldCenterA);
@@ -1486,7 +1486,7 @@ namespace BepuPhysics.Constraints.Contact
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact4PrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref Contact4PrestepData prestep, ref Contact4AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.

--- a/BepuPhysics/Constraints/Contact/ContactConvexTypes.tt
+++ b/BepuPhysics/Constraints/Contact/ContactConvexTypes.tt
@@ -24,23 +24,23 @@ namespace BepuPhysics.Constraints.Contact
         public Vector<float> Twist;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector2Wide GetTangentFriction(ref Contact<#= contactCount #>AccumulatedImpulses impulses)
+        public static ref Vector2Wide GetTangentFriction(ref Contact<#= contactCount #>AccumulatedImpulses impulses)
         {
             return ref impulses.Tangent;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetTwistFriction(ref Contact<#= contactCount #>AccumulatedImpulses impulses)
+        public static ref Vector<float> GetTwistFriction(ref Contact<#= contactCount #>AccumulatedImpulses impulses)
         {
             return ref impulses.Twist;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector<float> GetPenetrationImpulseForContact(ref Contact<#= contactCount #>AccumulatedImpulses impulses, int index)
+        public static ref Vector<float> GetPenetrationImpulseForContact(ref Contact<#= contactCount #>AccumulatedImpulses impulses, int index)
         {
             Debug.Assert(index >= 0 && index < <#=contactCount#>);
             return ref Unsafe.Add(ref impulses.Penetration0, index);
         }
-        public int ContactCount => <#=contactCount#>;
+        public static int ContactCount => <#=contactCount#>;
     }
 
 <#}#>
@@ -125,7 +125,7 @@ for (int i = 0; i < contactCount; ++i)
             GetFirst(ref target.MaterialProperties.MaximumRecoveryVelocity) = MaximumRecoveryVelocity;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact<#= contactCount #><#=suffix#> description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact<#= contactCount #><#=suffix#> description)
         {    
             Debug.Assert(batch.TypeId == ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<Contact<#=contactCount#><#=suffix#>PrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -155,19 +155,19 @@ for (int i = 0; i < contactCount; ++i)
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConstraintContactData GetFirstContact(ref Contact<#= contactCount #><#=suffix#> description)
+        public static ref ConstraintContactData GetFirstContact(ref Contact<#= contactCount #><#=suffix#> description)
         {
             return ref description.Contact0;
         }
         
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact<#= contactCount #><#=suffix#>TypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact<#= contactCount #><#=suffix#>TypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact<#= contactCount #><#=suffix#>TypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact<#= contactCount #><#=suffix#>TypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact<#= contactCount #><#=suffix#>TypeProcessor();
 
     }
 
@@ -186,30 +186,30 @@ for (int i = 0; i < contactCount; ++i)
         public Vector3Wide Normal;
         public MaterialPropertiesWide MaterialProperties;
 		
-        public readonly int BodyCount => <#=bodyCount#>;
-        public readonly int ContactCount => <#=contactCount#>;
+        public static int BodyCount => <#=bodyCount#>;
+        public static int ContactCount => <#=contactCount#>;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetNormal(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep)
+        public static ref Vector3Wide GetNormal(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep)
         {
             return ref prestep.Normal;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref ConvexContactWide GetContact(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep, int index)
+        public static ref ConvexContactWide GetContact(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
 <#if (bodyCount == 2){#>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact<#= contactCount #><#=suffix#>PrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
@@ -219,10 +219,10 @@ for (int i = 0; i < contactCount; ++i)
 
     public struct Contact<#=contactCount#><#=suffix#>Functions : I<#=bodyCount == 1 ? "OneBody" : "TwoBody"#>ConstraintFunctions<Contact<#=contactCount#><#=suffix#>PrestepData, Contact<#=contactCount#>AccumulatedImpulses>
     {       
-        public bool RequiresIncrementalSubstepUpdates => true;
+        public static bool RequiresIncrementalSubstepUpdates => true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA,<#if(bodyCount == 2) {#> in BodyVelocityWide velocityB,<#}#> ref Contact<#=contactCount#><#=suffix#>PrestepData prestep)
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA,<#if(bodyCount == 2) {#> in BodyVelocityWide velocityB,<#}#> ref Contact<#=contactCount#><#=suffix#>PrestepData prestep)
         {
 <#for (int i = 0; i < contactCount; ++i) {#>
             PenetrationLimit<#=suffix#>.UpdatePenetrationDepth(dt, prestep.Contact<#=i#>.OffsetA, <#if(bodyCount == 2) {#>prestep.OffsetB, <#}#>prestep.Normal, velocityA, <#if (bodyCount == 2) {#>velocityB, <#}#>ref prestep.Contact<#=i#>.Depth);
@@ -230,7 +230,7 @@ for (int i = 0; i < contactCount; ++i)
         }
                
         [MethodImpl(MethodImplOptions.AggressiveInlining)] 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(bodyCount == 2) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>ref Contact<#=contactCount#><#=suffix#>PrestepData prestep, ref Contact<#=contactCount#>AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA<#if(bodyCount == 2) {#>, ref BodyVelocityWide wsvB<#}#>)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(bodyCount == 2) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>ref Contact<#=contactCount#><#=suffix#>PrestepData prestep, ref Contact<#=contactCount#>AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA<#if(bodyCount == 2) {#>, ref BodyVelocityWide wsvB<#}#>)
         {
             Helpers.BuildOrthonormalBasis(prestep.Normal, out var x, out var z);
 <#if (contactCount > 1) {#>
@@ -249,7 +249,7 @@ for (int i = 0; i < contactCount; ++i)
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(bodyCount == 2) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>float dt, float inverseDt, ref Contact<#=contactCount#><#=suffix#>PrestepData prestep, ref Contact<#=contactCount#>AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA<#if(bodyCount == 2) {#>, ref BodyVelocityWide wsvB<#}#>)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(bodyCount == 2) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>float dt, float inverseDt, ref Contact<#=contactCount#><#=suffix#>PrestepData prestep, ref Contact<#=contactCount#>AccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA<#if(bodyCount == 2) {#>, ref BodyVelocityWide wsvB<#}#>)
         {            
             //Note that we solve the penetration constraints before the friction constraints. 
             //This makes the friction constraints more authoritative, since they happen last.

--- a/BepuPhysics/Constraints/Contact/ContactNonconvexCommon.cs
+++ b/BepuPhysics/Constraints/Contact/ContactNonconvexCommon.cs
@@ -17,19 +17,19 @@ namespace BepuPhysics.Constraints.Contact
 
     public interface INonconvexContactPrestep<TPrestep> : IContactPrestep<TPrestep> where TPrestep : struct, INonconvexContactPrestep<TPrestep>
     {
-        ref NonconvexContactPrestepData GetContact(ref TPrestep prestep, int index);
+        static abstract ref NonconvexContactPrestepData GetContact(ref TPrestep prestep, int index);
 
     }
 
     public interface ITwoBodyNonconvexContactPrestep<TPrestep> : INonconvexContactPrestep<TPrestep> where TPrestep : struct, ITwoBodyNonconvexContactPrestep<TPrestep>
     {
-        ref Vector3Wide GetOffsetB(ref TPrestep prestep);
+        static abstract ref Vector3Wide GetOffsetB(ref TPrestep prestep);
     }
 
 
     public interface INonconvexContactAccumulatedImpulses<TAccumulatedImpulses> : IContactAccumulatedImpulses<TAccumulatedImpulses> where TAccumulatedImpulses : struct, INonconvexContactAccumulatedImpulses<TAccumulatedImpulses>
     {
-        ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref TAccumulatedImpulses impulses, int index);
+        static abstract ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref TAccumulatedImpulses impulses, int index);
     }
 
 
@@ -59,24 +59,24 @@ namespace BepuPhysics.Constraints.Contact
               where TPrestep : unmanaged, ITwoBodyNonconvexContactPrestep<TPrestep>
               where TDescription : unmanaged, INonconvexTwoBodyContactConstraintDescription<TDescription>
         {
-            Debug.Assert(batch.TypeId == description.ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
+            Debug.Assert(batch.TypeId == TDescription.ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var target = ref GetOffsetInstance(ref Buffer<TPrestep>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
 
-            ref var sourceCommon = ref description.GetCommonProperties(ref description);
-            ref var targetOffsetB = ref target.GetOffsetB(ref target);
+            ref var sourceCommon = ref TDescription.GetCommonProperties(ref description);
+            ref var targetOffsetB = ref TPrestep.GetOffsetB(ref target);
             GetFirst(ref targetOffsetB.X) = sourceCommon.OffsetB.X;
             GetFirst(ref targetOffsetB.Y) = sourceCommon.OffsetB.Y;
             GetFirst(ref targetOffsetB.Z) = sourceCommon.OffsetB.Z;
 
-            ref var targetMaterial = ref target.GetMaterialProperties(ref target);
+            ref var targetMaterial = ref TPrestep.GetMaterialProperties(ref target);
             GetFirst(ref targetMaterial.FrictionCoefficient) = sourceCommon.FrictionCoefficient;
             GetFirst(ref targetMaterial.SpringSettings.AngularFrequency) = sourceCommon.SpringSettings.AngularFrequency;
             GetFirst(ref targetMaterial.SpringSettings.TwiceDampingRatio) = sourceCommon.SpringSettings.TwiceDampingRatio;
             GetFirst(ref targetMaterial.MaximumRecoveryVelocity) = sourceCommon.MaximumRecoveryVelocity;
 
-            ref var sourceContacts = ref description.GetFirstContact(ref description);
-            ref var targetContacts = ref target.GetContact(ref target, 0);
-            CopyContactData(description.ContactCount, ref sourceContacts, ref targetContacts);
+            ref var sourceContacts = ref TDescription.GetFirstContact(ref description);
+            ref var targetContacts = ref TPrestep.GetContact(ref target, 0);
+            CopyContactData(TPrestep.ContactCount, ref sourceContacts, ref targetContacts);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -84,19 +84,19 @@ namespace BepuPhysics.Constraints.Contact
               where TPrestep : unmanaged, INonconvexContactPrestep<TPrestep>
               where TDescription : unmanaged, INonconvexOneBodyContactConstraintDescription<TDescription>
         {
-            Debug.Assert(batch.TypeId == description.ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
+            Debug.Assert(batch.TypeId == TDescription.ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var target = ref GetOffsetInstance(ref Buffer<TPrestep>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
 
-            ref var sourceCommon = ref description.GetCommonProperties(ref description);
-            ref var materialCommon = ref target.GetMaterialProperties(ref target);
+            ref var sourceCommon = ref TDescription.GetCommonProperties(ref description);
+            ref var materialCommon = ref TPrestep.GetMaterialProperties(ref target);
             GetFirst(ref materialCommon.FrictionCoefficient) = sourceCommon.FrictionCoefficient;
             GetFirst(ref materialCommon.SpringSettings.AngularFrequency) = sourceCommon.SpringSettings.AngularFrequency;
             GetFirst(ref materialCommon.SpringSettings.TwiceDampingRatio) = sourceCommon.SpringSettings.TwiceDampingRatio;
             GetFirst(ref materialCommon.MaximumRecoveryVelocity) = sourceCommon.MaximumRecoveryVelocity;
 
-            ref var sourceContacts = ref description.GetFirstContact(ref description);
-            ref var targetContacts = ref target.GetContact(ref target, 0);
-            CopyContactData(description.ContactCount, ref sourceContacts, ref targetContacts);
+            ref var sourceContacts = ref TDescription.GetFirstContact(ref description);
+            ref var targetContacts = ref TPrestep.GetContact(ref target, 0);
+            CopyContactData(TPrestep.ContactCount, ref sourceContacts, ref targetContacts);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -117,11 +117,11 @@ namespace BepuPhysics.Constraints.Contact
               where TPrestep : unmanaged, ITwoBodyNonconvexContactPrestep<TPrestep>
               where TDescription : unmanaged, INonconvexTwoBodyContactConstraintDescription<TDescription>
         {
-            Debug.Assert(batch.TypeId == default(TDescription).ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
+            Debug.Assert(batch.TypeId == TDescription.ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var prestep = ref GetOffsetInstance(ref Buffer<TPrestep>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
 
-            Vector3Wide.ReadFirst(prestep.GetOffsetB(ref prestep), out var offsetB);
-            ref var materialSource = ref prestep.GetMaterialProperties(ref prestep);
+            Vector3Wide.ReadFirst(TPrestep.GetOffsetB(ref prestep), out var offsetB);
+            ref var materialSource = ref TPrestep.GetMaterialProperties(ref prestep);
             PairMaterialProperties material;
             material.FrictionCoefficient = GetFirst(ref materialSource.FrictionCoefficient);
             material.SpringSettings.AngularFrequency = GetFirst(ref materialSource.SpringSettings.AngularFrequency);
@@ -132,9 +132,9 @@ namespace BepuPhysics.Constraints.Contact
             description = default;
             description.CopyManifoldWideProperties(ref offsetB, ref material);
 
-            ref var descriptionContacts = ref description.GetFirstContact(ref description);
-            ref var prestepContacts = ref prestep.GetContact(ref prestep, 0);
-            CopyContactData(description.ContactCount, ref prestepContacts, ref descriptionContacts);
+            ref var descriptionContacts = ref TDescription.GetFirstContact(ref description);
+            ref var prestepContacts = ref TPrestep.GetContact(ref prestep, 0);
+            CopyContactData(TPrestep.ContactCount, ref prestepContacts, ref descriptionContacts);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -142,10 +142,10 @@ namespace BepuPhysics.Constraints.Contact
               where TPrestep : unmanaged, INonconvexContactPrestep<TPrestep>
               where TDescription : unmanaged, INonconvexOneBodyContactConstraintDescription<TDescription>
         {
-            Debug.Assert(batch.TypeId == default(TDescription).ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
+            Debug.Assert(batch.TypeId == TDescription.ConstraintTypeId, "The type batch passed to the description must match the description's expected type.");
             ref var prestep = ref GetOffsetInstance(ref Buffer<TPrestep>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
 
-            ref var materialSource = ref prestep.GetMaterialProperties(ref prestep);
+            ref var materialSource = ref TPrestep.GetMaterialProperties(ref prestep);
             PairMaterialProperties material;
             material.FrictionCoefficient = GetFirst(ref materialSource.FrictionCoefficient);
             material.SpringSettings.AngularFrequency = GetFirst(ref materialSource.SpringSettings.AngularFrequency);
@@ -156,9 +156,9 @@ namespace BepuPhysics.Constraints.Contact
             description = default;
             description.CopyManifoldWideProperties(ref material);
 
-            ref var descriptionContacts = ref description.GetFirstContact(ref description);
-            ref var prestepContacts = ref prestep.GetContact(ref prestep, 0);
-            CopyContactData(description.ContactCount, ref prestepContacts, ref descriptionContacts);
+            ref var descriptionContacts = ref TDescription.GetFirstContact(ref description);
+            ref var prestepContacts = ref TPrestep.GetContact(ref prestep, 0);
+            CopyContactData(TPrestep.ContactCount, ref prestepContacts, ref descriptionContacts);
         }
     }
 
@@ -176,20 +176,20 @@ namespace BepuPhysics.Constraints.Contact
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementallyUpdateContactData(in Vector<float> dt, in BodyVelocityWide velocity, ref TPrestep prestep)
         {
-            ref var prestepContactStart = ref prestep.GetContact(ref prestep, 0);
-            for (int i = 0; i < prestep.ContactCount; ++i)
+            ref var prestepContactStart = ref TPrestep.GetContact(ref prestep, 0);
+            for (int i = 0; i < TPrestep.ContactCount; ++i)
             {
                 ref var prestepContact = ref Unsafe.Add(ref prestepContactStart, i);
                 PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestepContact.Offset, prestepContact.Normal, velocity, ref prestepContact.Depth);
             }
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
-            ref var prestepMaterial = ref prestep.GetMaterialProperties(ref prestep);
-            ref var prestepContactStart = ref prestep.GetContact(ref prestep, 0);
+            ref var prestepMaterial = ref TPrestep.GetMaterialProperties(ref prestep);
+            ref var prestepContactStart = ref TPrestep.GetContact(ref prestep, 0);
             ref var accumulatedImpulsesStart = ref Unsafe.As<TAccumulatedImpulses, NonconvexAccumulatedImpulses>(ref accumulatedImpulses);
-            for (int i = 0; i < prestep.ContactCount; ++i)
+            for (int i = 0; i < TPrestep.ContactCount; ++i)
             {
                 ref var prestepContact = ref Unsafe.Add(ref prestepContactStart, i);
                 Helpers.BuildOrthonormalBasis(prestepContact.Normal, out var x, out var z);
@@ -199,16 +199,16 @@ namespace BepuPhysics.Constraints.Contact
             }
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             //Note that, unlike convex manifolds, we simply solve every contact in sequence rather than tangent->penetration.
             //This is not for any principled reason- only simplicity. May want to reconsider later, but remember the significant change in access pattern.
-            ref var prestepMaterial = ref prestep.GetMaterialProperties(ref prestep);
+            ref var prestepMaterial = ref TPrestep.GetMaterialProperties(ref prestep);
             ref var accumulatedImpulsesStart = ref Unsafe.As<TAccumulatedImpulses, NonconvexAccumulatedImpulses>(ref accumulatedImpulses);
-            ref var prestepContactStart = ref prestep.GetContact(ref prestep, 0);
+            ref var prestepContactStart = ref TPrestep.GetContact(ref prestep, 0);
             SpringSettingsWide.ComputeSpringiness(prestepMaterial.SpringSettings, dt, out var positionErrorToVelocity, out var effectiveMassCFMScale, out var softnessImpulseScale);
             var inverseDtWide = new Vector<float>(inverseDt);
-            for (int i = 0; i < prestep.ContactCount; ++i)
+            for (int i = 0; i < TPrestep.ContactCount; ++i)
             {
                 ref var contact = ref Unsafe.Add(ref prestepContactStart, i);
                 ref var contactImpulse = ref Unsafe.Add(ref accumulatedImpulsesStart, i);
@@ -228,11 +228,11 @@ namespace BepuPhysics.Constraints.Contact
             throw new System.NotImplementedException();
         }
 
-        public bool RequiresIncrementalSubstepUpdates => true;
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref TPrestep prestep)
+        public static bool RequiresIncrementalSubstepUpdates => true;
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref TPrestep prestep)
         {
-            ref var prestepContactStart = ref prestep.GetContact(ref prestep, 0);
-            for (int i = 0; i < prestep.ContactCount; ++i)
+            ref var prestepContactStart = ref TPrestep.GetContact(ref prestep, 0);
+            for (int i = 0; i < TPrestep.ContactCount; ++i)
             {
                 ref var prestepContact = ref Unsafe.Add(ref prestepContactStart, i);
                 PenetrationLimitOneBody.UpdatePenetrationDepth(dt, prestepContact.Offset, prestepContact.Normal, wsvA, ref prestepContact.Depth);
@@ -245,13 +245,13 @@ namespace BepuPhysics.Constraints.Contact
         where TPrestep : struct, ITwoBodyNonconvexContactPrestep<TPrestep>
         where TAccumulatedImpulses : struct
     {
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
-            ref var prestepMaterial = ref prestep.GetMaterialProperties(ref prestep);
-            ref var prestepOffsetB = ref prestep.GetOffsetB(ref prestep);
-            ref var prestepContactStart = ref prestep.GetContact(ref prestep, 0);
+            ref var prestepMaterial = ref TPrestep.GetMaterialProperties(ref prestep);
+            ref var prestepOffsetB = ref TPrestep.GetOffsetB(ref prestep);
+            ref var prestepContactStart = ref TPrestep.GetContact(ref prestep, 0);
             ref var accumulatedImpulsesStart = ref Unsafe.As<TAccumulatedImpulses, NonconvexAccumulatedImpulses>(ref accumulatedImpulses);
-            for (int i = 0; i < prestep.ContactCount; ++i)
+            for (int i = 0; i < TPrestep.ContactCount; ++i)
             {
                 ref var prestepContact = ref Unsafe.Add(ref prestepContactStart, i);
                 Helpers.BuildOrthonormalBasis(prestepContact.Normal, out var x, out var z);
@@ -262,17 +262,17 @@ namespace BepuPhysics.Constraints.Contact
             }
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TPrestep prestep, ref TAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //Note that, unlike convex manifolds, we simply solve every contact in sequence rather than tangent->penetration.
             //This is not for any principled reason- only simplicity. May want to reconsider later, but remember the significant change in access pattern.
-            ref var prestepOffsetB = ref prestep.GetOffsetB(ref prestep);
-            ref var prestepMaterial = ref prestep.GetMaterialProperties(ref prestep);
+            ref var prestepOffsetB = ref TPrestep.GetOffsetB(ref prestep);
+            ref var prestepMaterial = ref TPrestep.GetMaterialProperties(ref prestep);
             ref var accumulatedImpulsesStart = ref Unsafe.As<TAccumulatedImpulses, NonconvexAccumulatedImpulses>(ref accumulatedImpulses);
-            ref var prestepContactStart = ref prestep.GetContact(ref prestep, 0);
+            ref var prestepContactStart = ref TPrestep.GetContact(ref prestep, 0);
             SpringSettingsWide.ComputeSpringiness(prestepMaterial.SpringSettings, dt, out var positionErrorToVelocity, out var effectiveMassCFMScale, out var softnessImpulseScale);
             var inverseDtWide = new Vector<float>(inverseDt);
-            for (int i = 0; i < prestep.ContactCount; ++i)
+            for (int i = 0; i < TPrestep.ContactCount; ++i)
             {
                 ref var contact = ref Unsafe.Add(ref prestepContactStart, i);
                 ref var contactImpulse = ref Unsafe.Add(ref accumulatedImpulsesStart, i);
@@ -286,12 +286,12 @@ namespace BepuPhysics.Constraints.Contact
         }
 
 
-        public bool RequiresIncrementalSubstepUpdates => true;
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TPrestep prestep)
+        public static bool RequiresIncrementalSubstepUpdates => true;
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TPrestep prestep)
         {
-            ref var prestepOffsetB = ref prestep.GetOffsetB(ref prestep);
-            ref var prestepContactStart = ref prestep.GetContact(ref prestep, 0);
-            for (int i = 0; i < prestep.ContactCount; ++i)
+            ref var prestepOffsetB = ref TPrestep.GetOffsetB(ref prestep);
+            ref var prestepContactStart = ref TPrestep.GetContact(ref prestep, 0);
+            for (int i = 0; i < TPrestep.ContactCount; ++i)
             {
                 ref var prestepContact = ref Unsafe.Add(ref prestepContactStart, i);
                 PenetrationLimit.UpdatePenetrationDepth(dt, prestepContact.Offset, prestepOffsetB, prestepContact.Normal, wsvA, wsvB, ref prestepContact.Depth);

--- a/BepuPhysics/Constraints/Contact/ContactNonconvexTypes.cs
+++ b/BepuPhysics/Constraints/Contact/ContactNonconvexTypes.cs
@@ -16,7 +16,7 @@ namespace BepuPhysics.Constraints.Contact
             NonconvexConstraintHelpers.ApplyTwoBodyDescription<Contact2Nonconvex, Contact2NonconvexPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2Nonconvex description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2Nonconvex description)
         {
             NonconvexConstraintHelpers.BuildTwoBodyDescription<Contact2Nonconvex, Contact2NonconvexPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -31,27 +31,27 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact2Nonconvex description)
+        public static ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact2Nonconvex description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact2Nonconvex description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact2Nonconvex description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => 2;
+        public static int ContactCount => 2;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact2NonconvexTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact2NonconvexTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact2NonconvexTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact2NonconvexTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact2NonconvexTypeProcessor();
 
     }
 
@@ -64,35 +64,35 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexContactPrestepData Contact1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact2NonconvexPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact2NonconvexPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact2NonconvexPrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact2NonconvexPrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexContactPrestepData GetContact(ref Contact2NonconvexPrestepData prestep, int index)
+        public static ref NonconvexContactPrestepData GetContact(ref Contact2NonconvexPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
         
-        public readonly int ContactCount => 2;
-        public readonly int BodyCount => 2;
+        public static int ContactCount => 2;
+        public static int BodyCount => 2;
     }
 
     public struct Contact2NonconvexAccumulatedImpulses : INonconvexContactAccumulatedImpulses<Contact2NonconvexAccumulatedImpulses>
     {
         public NonconvexAccumulatedImpulses Contact0;
         public NonconvexAccumulatedImpulses Contact1;
-        public readonly int ContactCount => 2;
+        public static int ContactCount => 2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref Contact2NonconvexAccumulatedImpulses impulses, int index)
+        public static ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref Contact2NonconvexAccumulatedImpulses impulses, int index)
         {
             return ref Unsafe.Add(ref impulses.Contact0, index);
         }
@@ -120,7 +120,7 @@ namespace BepuPhysics.Constraints.Contact
             NonconvexConstraintHelpers.ApplyOneBodyDescription<Contact2NonconvexOneBody, Contact2NonconvexOneBodyPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2NonconvexOneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact2NonconvexOneBody description)
         {
             NonconvexConstraintHelpers.BuildOneBodyDescription<Contact2NonconvexOneBody, Contact2NonconvexOneBodyPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -134,27 +134,27 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact2NonconvexOneBody description)
+        public static ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact2NonconvexOneBody description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact2NonconvexOneBody description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact2NonconvexOneBody description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => 2;
+        public static int ContactCount => 2;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact2NonconvexOneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact2NonconvexOneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact2NonconvexOneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact2NonconvexOneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact2NonconvexOneBodyTypeProcessor();
 
     }
 
@@ -166,19 +166,19 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexContactPrestepData Contact1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact2NonconvexOneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact2NonconvexOneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexContactPrestepData GetContact(ref Contact2NonconvexOneBodyPrestepData prestep, int index)
+        public static ref NonconvexContactPrestepData GetContact(ref Contact2NonconvexOneBodyPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
                 
-        public readonly int ContactCount => 2;
-        public readonly int BodyCount => 1;
+        public static int ContactCount => 2;
+        public static int BodyCount => 1;
     }    
 
     /// <summary>
@@ -205,7 +205,7 @@ namespace BepuPhysics.Constraints.Contact
             NonconvexConstraintHelpers.ApplyTwoBodyDescription<Contact3Nonconvex, Contact3NonconvexPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3Nonconvex description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3Nonconvex description)
         {
             NonconvexConstraintHelpers.BuildTwoBodyDescription<Contact3Nonconvex, Contact3NonconvexPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -220,27 +220,27 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact3Nonconvex description)
+        public static ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact3Nonconvex description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact3Nonconvex description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact3Nonconvex description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => 3;
+        public static int ContactCount => 3;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact3NonconvexTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact3NonconvexTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact3NonconvexTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact3NonconvexTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact3NonconvexTypeProcessor();
 
     }
 
@@ -254,25 +254,25 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexContactPrestepData Contact2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact3NonconvexPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact3NonconvexPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact3NonconvexPrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact3NonconvexPrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexContactPrestepData GetContact(ref Contact3NonconvexPrestepData prestep, int index)
+        public static ref NonconvexContactPrestepData GetContact(ref Contact3NonconvexPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
         
-        public readonly int ContactCount => 3;
-        public readonly int BodyCount => 2;
+        public static int ContactCount => 3;
+        public static int BodyCount => 2;
     }
 
     public struct Contact3NonconvexAccumulatedImpulses : INonconvexContactAccumulatedImpulses<Contact3NonconvexAccumulatedImpulses>
@@ -280,10 +280,10 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexAccumulatedImpulses Contact0;
         public NonconvexAccumulatedImpulses Contact1;
         public NonconvexAccumulatedImpulses Contact2;
-        public readonly int ContactCount => 3;
+        public static int ContactCount => 3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref Contact3NonconvexAccumulatedImpulses impulses, int index)
+        public static ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref Contact3NonconvexAccumulatedImpulses impulses, int index)
         {
             return ref Unsafe.Add(ref impulses.Contact0, index);
         }
@@ -312,7 +312,7 @@ namespace BepuPhysics.Constraints.Contact
             NonconvexConstraintHelpers.ApplyOneBodyDescription<Contact3NonconvexOneBody, Contact3NonconvexOneBodyPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3NonconvexOneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact3NonconvexOneBody description)
         {
             NonconvexConstraintHelpers.BuildOneBodyDescription<Contact3NonconvexOneBody, Contact3NonconvexOneBodyPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -326,27 +326,27 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact3NonconvexOneBody description)
+        public static ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact3NonconvexOneBody description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact3NonconvexOneBody description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact3NonconvexOneBody description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => 3;
+        public static int ContactCount => 3;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact3NonconvexOneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact3NonconvexOneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact3NonconvexOneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact3NonconvexOneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact3NonconvexOneBodyTypeProcessor();
 
     }
 
@@ -359,19 +359,19 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexContactPrestepData Contact2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact3NonconvexOneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact3NonconvexOneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexContactPrestepData GetContact(ref Contact3NonconvexOneBodyPrestepData prestep, int index)
+        public static ref NonconvexContactPrestepData GetContact(ref Contact3NonconvexOneBodyPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
                 
-        public readonly int ContactCount => 3;
-        public readonly int BodyCount => 1;
+        public static int ContactCount => 3;
+        public static int BodyCount => 1;
     }    
 
     /// <summary>
@@ -399,7 +399,7 @@ namespace BepuPhysics.Constraints.Contact
             NonconvexConstraintHelpers.ApplyTwoBodyDescription<Contact4Nonconvex, Contact4NonconvexPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4Nonconvex description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4Nonconvex description)
         {
             NonconvexConstraintHelpers.BuildTwoBodyDescription<Contact4Nonconvex, Contact4NonconvexPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -414,27 +414,27 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact4Nonconvex description)
+        public static ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact4Nonconvex description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact4Nonconvex description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact4Nonconvex description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => 4;
+        public static int ContactCount => 4;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact4NonconvexTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact4NonconvexTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact4NonconvexTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact4NonconvexTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact4NonconvexTypeProcessor();
 
     }
 
@@ -449,25 +449,25 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexContactPrestepData Contact3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact4NonconvexPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact4NonconvexPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact4NonconvexPrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact4NonconvexPrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexContactPrestepData GetContact(ref Contact4NonconvexPrestepData prestep, int index)
+        public static ref NonconvexContactPrestepData GetContact(ref Contact4NonconvexPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
         
-        public readonly int ContactCount => 4;
-        public readonly int BodyCount => 2;
+        public static int ContactCount => 4;
+        public static int BodyCount => 2;
     }
 
     public struct Contact4NonconvexAccumulatedImpulses : INonconvexContactAccumulatedImpulses<Contact4NonconvexAccumulatedImpulses>
@@ -476,10 +476,10 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexAccumulatedImpulses Contact1;
         public NonconvexAccumulatedImpulses Contact2;
         public NonconvexAccumulatedImpulses Contact3;
-        public readonly int ContactCount => 4;
+        public static int ContactCount => 4;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref Contact4NonconvexAccumulatedImpulses impulses, int index)
+        public static ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref Contact4NonconvexAccumulatedImpulses impulses, int index)
         {
             return ref Unsafe.Add(ref impulses.Contact0, index);
         }
@@ -509,7 +509,7 @@ namespace BepuPhysics.Constraints.Contact
             NonconvexConstraintHelpers.ApplyOneBodyDescription<Contact4NonconvexOneBody, Contact4NonconvexOneBodyPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4NonconvexOneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact4NonconvexOneBody description)
         {
             NonconvexConstraintHelpers.BuildOneBodyDescription<Contact4NonconvexOneBody, Contact4NonconvexOneBodyPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -523,27 +523,27 @@ namespace BepuPhysics.Constraints.Contact
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact4NonconvexOneBody description)
+        public static ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact4NonconvexOneBody description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact4NonconvexOneBody description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact4NonconvexOneBody description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => 4;
+        public static int ContactCount => 4;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact4NonconvexOneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact4NonconvexOneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact4NonconvexOneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact4NonconvexOneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact4NonconvexOneBodyTypeProcessor();
 
     }
 
@@ -557,19 +557,19 @@ namespace BepuPhysics.Constraints.Contact
         public NonconvexContactPrestepData Contact3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact4NonconvexOneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact4NonconvexOneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexContactPrestepData GetContact(ref Contact4NonconvexOneBodyPrestepData prestep, int index)
+        public static ref NonconvexContactPrestepData GetContact(ref Contact4NonconvexOneBodyPrestepData prestep, int index)
         {
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
                 
-        public readonly int ContactCount => 4;
-        public readonly int BodyCount => 1;
+        public static int ContactCount => 4;
+        public static int BodyCount => 1;
     }    
 
     /// <summary>

--- a/BepuPhysics/Constraints/Contact/ContactNonconvexTypes.tt
+++ b/BepuPhysics/Constraints/Contact/ContactNonconvexTypes.tt
@@ -29,7 +29,7 @@ for (int i = 0; i < contactCount ; ++i)
             NonconvexConstraintHelpers.ApplyTwoBodyDescription<Contact<#= contactCount #>Nonconvex, Contact<#= contactCount #>NonconvexPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact<#= contactCount #>Nonconvex description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact<#= contactCount #>Nonconvex description)
         {
             NonconvexConstraintHelpers.BuildTwoBodyDescription<Contact<#= contactCount #>Nonconvex, Contact<#= contactCount #>NonconvexPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -44,27 +44,27 @@ for (int i = 0; i < contactCount ; ++i)
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact<#=contactCount#>Nonconvex description)
+        public static ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref Contact<#=contactCount#>Nonconvex description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact<#= contactCount #>Nonconvex description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact<#= contactCount #>Nonconvex description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => <#= contactCount #>;
+        public static int ContactCount => <#= contactCount #>;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact<#= contactCount #>NonconvexTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact<#= contactCount #>NonconvexTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact<#= contactCount #>NonconvexTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact<#= contactCount #>NonconvexTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact<#= contactCount #>NonconvexTypeProcessor();
 
     }
 
@@ -80,13 +80,13 @@ for (int i = 0; i < contactCount; ++i)
 <#}#>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact<#= contactCount #>NonconvexPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact<#= contactCount #>NonconvexPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref Vector3Wide GetOffsetB(ref Contact<#= contactCount #>NonconvexPrestepData prestep)
+        public static ref Vector3Wide GetOffsetB(ref Contact<#= contactCount #>NonconvexPrestepData prestep)
         {
             return ref prestep.OffsetB;
         }
@@ -97,8 +97,8 @@ for (int i = 0; i < contactCount; ++i)
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
         
-        public readonly int ContactCount => <#= contactCount #>;
-        public readonly int BodyCount => 2;
+        public static int ContactCount => <#= contactCount #>;
+        public static int BodyCount => 2;
     }
 
     public struct Contact<#= contactCount #>NonconvexAccumulatedImpulses : INonconvexContactAccumulatedImpulses<Contact<#= contactCount #>NonconvexAccumulatedImpulses>
@@ -108,7 +108,7 @@ for (int i = 0; i < contactCount ; ++i)
 {#>
         public NonconvexAccumulatedImpulses Contact<#=i#>;
 <#}#>
-        public readonly int ContactCount => <#=contactCount#>;
+        public static int ContactCount => <#=contactCount#>;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref NonconvexAccumulatedImpulses GetImpulsesForContact(ref Contact<#= contactCount #>NonconvexAccumulatedImpulses impulses, int index)
@@ -142,7 +142,7 @@ for (int i = 0; i < contactCount ; ++i)
             NonconvexConstraintHelpers.ApplyOneBodyDescription<Contact<#= contactCount #>NonconvexOneBody, Contact<#= contactCount #>NonconvexOneBodyPrestepData>(ref this, ref batch, bundleIndex, innerIndex);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact<#= contactCount #>NonconvexOneBody description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Contact<#= contactCount #>NonconvexOneBody description)
         {
             NonconvexConstraintHelpers.BuildOneBodyDescription<Contact<#= contactCount #>NonconvexOneBody, Contact<#= contactCount #>NonconvexOneBodyPrestepData>(ref batch, bundleIndex, innerIndex, out description);
         }
@@ -156,27 +156,27 @@ for (int i = 0; i < contactCount ; ++i)
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact<#=contactCount#>NonconvexOneBody description)
+        public static ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref Contact<#=contactCount#>NonconvexOneBody description)
         {
             return ref description.Common;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref NonconvexConstraintContactData GetFirstContact(ref Contact<#= contactCount #>NonconvexOneBody description)
+        public static ref NonconvexConstraintContactData GetFirstContact(ref Contact<#= contactCount #>NonconvexOneBody description)
         {
             return ref description.Contact0;
         }
 
-        public readonly int ContactCount => <#= contactCount #>;
+        public static int ContactCount => <#= contactCount #>;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Contact<#= contactCount #>NonconvexOneBodyTypeProcessor.BatchTypeId;
         }
         
-        public readonly Type TypeProcessorType => typeof(Contact<#= contactCount #>NonconvexOneBodyTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new Contact<#= contactCount #>NonconvexOneBodyTypeProcessor();
+        public static Type TypeProcessorType => typeof(Contact<#= contactCount #>NonconvexOneBodyTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new Contact<#= contactCount #>NonconvexOneBodyTypeProcessor();
 
     }
 
@@ -191,7 +191,7 @@ for (int i = 0; i < contactCount ; ++i)
 <#}#>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref MaterialPropertiesWide GetMaterialProperties(ref Contact<#= contactCount #>NonconvexOneBodyPrestepData prestep)
+        public static ref MaterialPropertiesWide GetMaterialProperties(ref Contact<#= contactCount #>NonconvexOneBodyPrestepData prestep)
         {
             return ref prestep.MaterialProperties;
         }
@@ -202,8 +202,8 @@ for (int i = 0; i < contactCount ; ++i)
             return ref Unsafe.Add(ref prestep.Contact0, index);
         }
                 
-        public readonly int ContactCount => <#= contactCount #>;
-        public readonly int BodyCount => 1;
+        public static int ContactCount => <#= contactCount #>;
+        public static int BodyCount => 1;
     }    
 
     /// <summary>

--- a/BepuPhysics/Constraints/Contact/IContactConstraintDescription.cs
+++ b/BepuPhysics/Constraints/Contact/IContactConstraintDescription.cs
@@ -15,13 +15,13 @@ namespace BepuPhysics.Constraints.Contact
         where TDescription : unmanaged, IConvexOneBodyContactConstraintDescription<TDescription>
     {
         void CopyManifoldWideProperties(ref Vector3 normal, ref PairMaterialProperties material);
-        ref ConstraintContactData GetFirstContact(ref TDescription description);
+        static abstract ref ConstraintContactData GetFirstContact(ref TDescription description);
     }
     public interface IConvexTwoBodyContactConstraintDescription<TDescription> : ITwoBodyConstraintDescription<TDescription> 
         where TDescription : unmanaged, IConvexTwoBodyContactConstraintDescription<TDescription>
     {
         void CopyManifoldWideProperties(ref Vector3 offsetB, ref Vector3 normal, ref PairMaterialProperties material);
-        ref ConstraintContactData GetFirstContact(ref TDescription description);
+        static abstract ref ConstraintContactData GetFirstContact(ref TDescription description);
     }
 
     public struct NonconvexConstraintContactData
@@ -49,19 +49,19 @@ namespace BepuPhysics.Constraints.Contact
         where TDescription : unmanaged, INonconvexOneBodyContactConstraintDescription<TDescription>
     {
         void CopyManifoldWideProperties(ref PairMaterialProperties material);
-        int ContactCount { get; }
+        static abstract int ContactCount { get; }
 
-        ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref TDescription description);
-        ref NonconvexConstraintContactData GetFirstContact(ref TDescription description);
+        static abstract ref NonconvexOneBodyManifoldConstraintProperties GetCommonProperties(ref TDescription description);
+        static abstract ref NonconvexConstraintContactData GetFirstContact(ref TDescription description);
     }
     public interface INonconvexTwoBodyContactConstraintDescription<TDescription> : ITwoBodyConstraintDescription<TDescription> 
         where TDescription : unmanaged, INonconvexTwoBodyContactConstraintDescription<TDescription>
     {
         void CopyManifoldWideProperties(ref Vector3 offsetB, ref PairMaterialProperties material);
-        int ContactCount { get; }
+        static abstract int ContactCount { get; }
 
-        ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref TDescription description);
-        ref NonconvexConstraintContactData GetFirstContact(ref TDescription description);
+        static abstract ref NonconvexTwoBodyManifoldConstraintProperties GetCommonProperties(ref TDescription description);
+        static abstract ref NonconvexConstraintContactData GetFirstContact(ref TDescription description);
     }
 
 }

--- a/BepuPhysics/Constraints/DistanceLimit.cs
+++ b/BepuPhysics/Constraints/DistanceLimit.cs
@@ -53,7 +53,7 @@ namespace BepuPhysics.Constraints
             SpringSettings = springSettings;
         }
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -62,8 +62,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(DistanceLimitTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new DistanceLimitTypeProcessor();
+        public static Type TypeProcessorType => typeof(DistanceLimitTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new DistanceLimitTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -80,7 +80,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out DistanceLimit description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out DistanceLimit description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<DistanceLimitPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -116,7 +116,7 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ComputeJacobians(
+        public static void ComputeJacobians(
             in Vector3Wide localOffsetA, in Vector3Wide positionA, in QuaternionWide orientationA, in Vector3Wide localOffsetB, in Vector3Wide positionB, in QuaternionWide orientationB,
             in Vector<float> minimumDistance, in Vector<float> maximumDistance, out Vector<int> useMinimum, out Vector<float> distance, out Vector3Wide direction, out Vector3Wide angularJA, out Vector3Wide angularJB)
         {
@@ -139,14 +139,14 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref DistanceLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref DistanceLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(prestep.LocalOffsetA, positionA, orientationA, prestep.LocalOffsetB, positionB, orientationB, prestep.MinimumDistance, prestep.MaximumDistance, out _, out _, out var direction, out var angularJA, out var angularJB);
             ApplyImpulse(direction, angularJA, angularJB, inertiaA, inertiaB, accumulatedImpulses, ref wsvA, ref wsvB);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref DistanceLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref DistanceLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(prestep.LocalOffsetA, positionA, orientationA, prestep.LocalOffsetB, positionB, orientationB, prestep.MinimumDistance, prestep.MaximumDistance, out var useMinimum, out var distance, out var direction, out var angularJA, out var angularJB);
 
@@ -172,9 +172,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(direction, angularJA, angularJB, inertiaA, inertiaB, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref DistanceLimitPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref DistanceLimitPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/Constraints/DistanceServo.cs
+++ b/BepuPhysics/Constraints/DistanceServo.cs
@@ -59,7 +59,7 @@ namespace BepuPhysics.Constraints
         {
         }
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -68,8 +68,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(DistanceServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new DistanceServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(DistanceServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new DistanceServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -84,7 +84,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out DistanceServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out DistanceServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<DistanceServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -183,7 +183,7 @@ namespace BepuPhysics.Constraints
         }
 
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref DistanceServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref DistanceServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             GetDistance(orientationA, positionB - positionA, orientationB, prestep.LocalOffsetA, prestep.LocalOffsetB, out var anchorOffsetA, out var anchorOffsetB, out var anchorOffset, out var distance);
             Vector3Wide.Scale(anchorOffset, Vector<float>.One / distance, out var direction);
@@ -193,7 +193,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(inertiaA.InverseMass, inertiaB.InverseMass, direction, angularImpulseToVelocityA, angularImpulseToVelocityB, accumulatedImpulses, ref wsvA, ref wsvB);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref DistanceServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref DistanceServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             GetDistance(orientationA, positionB - positionA, orientationB, prestep.LocalOffsetA, prestep.LocalOffsetB, out var anchorOffsetA, out var anchorOffsetB, out var anchorOffset, out var distance);
 
@@ -217,9 +217,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(inertiaA.InverseMass, inertiaB.InverseMass, direction, angularImpulseToVelocityA, angularImpulseToVelocityB, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref DistanceServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref DistanceServoPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/Constraints/FourBodyTypeProcessor.cs
+++ b/BepuPhysics/Constraints/FourBodyTypeProcessor.cs
@@ -26,13 +26,13 @@ namespace BepuPhysics.Constraints
     /// <typeparam name="TAccumulatedImpulse">Type of the accumulated impulses used by the constraint.</typeparam>
     public interface IFourBodyConstraintFunctions<TPrestepData, TAccumulatedImpulse>
     {
-        void WarmStart(
+        static abstract void WarmStart(
             in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA,
             in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
             in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC,
             in Vector3Wide positionD, in QuaternionWide orientationD, in BodyInertiaWide inertiaD,
             ref TPrestepData prestep, ref TAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB, ref BodyVelocityWide wsvC, ref BodyVelocityWide wsvD);
-        void Solve(
+        static abstract void Solve(
             in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA,
             in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
             in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC,
@@ -42,8 +42,8 @@ namespace BepuPhysics.Constraints
         /// <summary>
         /// Gets whether this constraint type requires incremental updates for each substep taken beyond the first.
         /// </summary>
-        bool RequiresIncrementalSubstepUpdates { get; }
-        void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, in BodyVelocityWide wsvC, in BodyVelocityWide wsvD, ref TPrestepData prestepData);
+        static abstract bool RequiresIncrementalSubstepUpdates { get; }
+        static abstract void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, in BodyVelocityWide wsvC, in BodyVelocityWide wsvD, ref TPrestepData prestepData);
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ namespace BepuPhysics.Constraints
         struct FourBodySortKeyGenerator : ISortKeyGenerator<FourBodyReferences>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int GetSortKey(int constraintIndex, ref Buffer<FourBodyReferences> bodyReferences)
+            public static int GetSortKey(int constraintIndex, ref Buffer<FourBodyReferences> bodyReferences)
             {
                 BundleIndexing.GetBundleIndices(constraintIndex, out var bundleIndex, out var innerIndex);
                 ref var bundleReferences = ref bodyReferences[bundleIndex];
@@ -104,15 +104,13 @@ namespace BepuPhysics.Constraints
             VerifySortRegion<FourBodySortKeyGenerator>(ref typeBatch, bundleStartIndex, constraintCount, ref sortedKeys, ref sortedSourceIndices);
         }
 
-        public unsafe override void WarmStart<TIntegratorCallbacks, TBatchIntegrationMode, TAllowPoseIntegration>(
+        public override void WarmStart<TIntegratorCallbacks, TBatchIntegrationMode, TAllowPoseIntegration>(
             ref TypeBatch typeBatch, ref Buffer<IndexSet> integrationFlags, Bodies bodies, ref TIntegratorCallbacks integratorCallbacks,
             float dt, float inverseDt, int startBundle, int exclusiveEndBundle, int workerIndex)
         {
             var prestepBundles = typeBatch.PrestepData.As<TPrestepData>();
             var bodyReferencesBundles = typeBatch.BodyReferences.As<FourBodyReferences>();
             var accumulatedImpulsesBundles = typeBatch.AccumulatedImpulses.As<TAccumulatedImpulse>();
-            var function = default(TConstraintFunctions);
-            ref var states = ref bodies.ActiveSet.DynamicsState;
             for (int i = startBundle; i < exclusiveEndBundle; ++i)
             {
                 ref var prestep = ref prestepBundles[i];
@@ -130,7 +128,7 @@ namespace BepuPhysics.Constraints
                 //if (typeof(TAllowPoseIntegration) == typeof(AllowPoseIntegration))
                 //    function.UpdateForNewPose(positionA, orientationA, inertiaA, wsvA, positionB, orientationB, inertiaB, wsvB, positionC, orientationC, inertiaC, wsvC, positionD, orientationD, inertiaD, wsvD, new Vector<float>(dt), accumulatedImpulses, ref prestep);
 
-                function.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD, ref prestep, ref accumulatedImpulses, ref wsvA, ref wsvB, ref wsvC, ref wsvD);
+                TConstraintFunctions.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD, ref prestep, ref accumulatedImpulses, ref wsvA, ref wsvB, ref wsvC, ref wsvD);
 
                 if (typeof(TBatchIntegrationMode) == typeof(BatchShouldNeverIntegrate))
                 {
@@ -157,8 +155,6 @@ namespace BepuPhysics.Constraints
             var prestepBundles = typeBatch.PrestepData.As<TPrestepData>();
             var bodyReferencesBundles = typeBatch.BodyReferences.As<FourBodyReferences>();
             var accumulatedImpulsesBundles = typeBatch.AccumulatedImpulses.As<TAccumulatedImpulse>();
-            var function = default(TConstraintFunctions);
-            ref var motionStates = ref bodies.ActiveSet.DynamicsState;
             for (int i = startBundle; i < exclusiveEndBundle; ++i)
             {
                 ref var prestep = ref prestepBundles[i];
@@ -169,7 +165,7 @@ namespace BepuPhysics.Constraints
                 bodies.GatherState<TSolveAccessFilterC>(references.IndexC, true, out var positionC, out var orientationC, out var wsvC, out var inertiaC);
                 bodies.GatherState<TSolveAccessFilterD>(references.IndexD, true, out var positionD, out var orientationD, out var wsvD, out var inertiaD);
 
-                function.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD, dt, inverseDt, ref prestep, ref accumulatedImpulses, ref wsvA, ref wsvB, ref wsvC, ref wsvD);
+                TConstraintFunctions.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD, dt, inverseDt, ref prestep, ref accumulatedImpulses, ref wsvA, ref wsvB, ref wsvC, ref wsvD);
 
                 bodies.ScatterVelocities<TSolveAccessFilterA>(ref wsvA, ref references.IndexA);
                 bodies.ScatterVelocities<TSolveAccessFilterB>(ref wsvB, ref references.IndexB);
@@ -178,12 +174,11 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public override bool RequiresIncrementalSubstepUpdates => default(TConstraintFunctions).RequiresIncrementalSubstepUpdates;
+        public override bool RequiresIncrementalSubstepUpdates => TConstraintFunctions.RequiresIncrementalSubstepUpdates;
         public unsafe override void IncrementallyUpdateForSubstep(ref TypeBatch typeBatch, Bodies bodies, float dt, float inverseDt, int startBundle, int exclusiveEndBundle)
         {
             var prestepBundles = typeBatch.PrestepData.As<TPrestepData>();
             var bodyReferencesBundles = typeBatch.BodyReferences.As<FourBodyReferences>();
-            var function = default(TConstraintFunctions);
             var dtWide = new Vector<float>(dt);
             for (int i = startBundle; i < exclusiveEndBundle; ++i)
             {
@@ -193,7 +188,7 @@ namespace BepuPhysics.Constraints
                 bodies.GatherState<AccessOnlyVelocity>(references.IndexB, true, out _, out _, out var wsvB, out _);
                 bodies.GatherState<AccessOnlyVelocity>(references.IndexC, true, out _, out _, out var wsvC, out _);
                 bodies.GatherState<AccessOnlyVelocity>(references.IndexD, true, out _, out _, out var wsvD, out _);
-                function.IncrementallyUpdateForSubstep(dtWide, wsvA, wsvB, wsvC, wsvD, ref prestep);
+                TConstraintFunctions.IncrementallyUpdateForSubstep(dtWide, wsvA, wsvB, wsvC, wsvD, ref prestep);
             }
         }
 

--- a/BepuPhysics/Constraints/Hinge.cs
+++ b/BepuPhysics/Constraints/Hinge.cs
@@ -34,7 +34,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -43,8 +43,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(HingeTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new HingeTypeProcessor();
+        public static Type TypeProcessorType => typeof(HingeTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new HingeTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -60,7 +60,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Hinge description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Hinge description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<HingePrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -114,7 +114,7 @@ namespace BepuPhysics.Constraints
             Vector3Wide.Add(velocityB.Angular, angularChangeB, out velocityB.Angular);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref HingePrestepData prestep, ref HingeAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref HingePrestepData prestep, ref HingeAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             Matrix3x3Wide.CreateFromQuaternion(orientationA, out var orientationMatrixA);
             Matrix3x3Wide.TransformWithoutOverlap(prestep.LocalOffsetA, orientationMatrixA, out var offsetA);
@@ -126,7 +126,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(offsetA, offsetB, hingeJacobian, inertiaA, inertiaB, accumulatedImpulses, ref wsvA, ref wsvB);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref HingePrestepData prestep, ref HingeAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref HingePrestepData prestep, ref HingeAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //5x12 jacobians, from BallSocket and AngularHinge:
             //[ I, skew(offsetA),   -I, -skew(offsetB)    ]
@@ -217,9 +217,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(offsetA, offsetB, hingeJacobian, inertiaA, inertiaB, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref HingePrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref HingePrestepData prestepData) { }
     }
 
     public class HingeTypeProcessor : TwoBodyTypeProcessor<HingePrestepData, HingeAccumulatedImpulses, HingeFunctions, AccessNoPosition, AccessNoPosition, AccessAll, AccessAll>

--- a/BepuPhysics/Constraints/IConstraintDescription.cs
+++ b/BepuPhysics/Constraints/IConstraintDescription.cs
@@ -32,20 +32,20 @@ namespace BepuPhysics.Constraints
         /// <param name="bundleIndex">Index of the source constraint's bundle.</param>
         /// <param name="innerIndex">Index of the source constraint within its bundle.</param>
         /// <param name="description">Description of the constraint.</param>
-        void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TDescription description);
+        static abstract void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TDescription description);
         
         /// <summary>
         /// Gets the type id of the constraint that this is a description of.
         /// </summary>
-        int ConstraintTypeId { get; }
+        static abstract int ConstraintTypeId { get; }
         /// <summary>
         /// Gets the type of the type batch which contains described constraints.
         /// </summary>
-        Type TypeProcessorType  { get; }
+        static abstract Type TypeProcessorType  { get; }
         /// <summary>
         /// Creates a type processor for this constraint type.
         /// </summary>
-        TypeProcessor CreateTypeProcessor();
+        static abstract TypeProcessor CreateTypeProcessor();
     }
 
     /// <summary>

--- a/BepuPhysics/Constraints/LinearAxisLimit.cs
+++ b/BepuPhysics/Constraints/LinearAxisLimit.cs
@@ -38,7 +38,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -47,8 +47,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(LinearAxisLimitTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new LinearAxisLimitTypeProcessor();
+        public static Type TypeProcessorType => typeof(LinearAxisLimitTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new LinearAxisLimitTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -65,7 +65,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out LinearAxisLimit description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out LinearAxisLimit description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<LinearAxisLimitPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -119,7 +119,7 @@ namespace BepuPhysics.Constraints
             Vector3Wide.CrossWithoutOverlap(normal, offsetB, out angularJB);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref LinearAxisLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref LinearAxisLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(positionB - positionA, orientationA, orientationB, prestep.LocalPlaneNormal, prestep.LocalOffsetA, prestep.LocalOffsetB, prestep.MinimumOffset, prestep.MaximumOffset, out _, out var normal, out var angularJA, out var angularJB);
             Symmetric3x3Wide.TransformWithoutOverlap(angularJA, inertiaA.InverseInertiaTensor, out var angularImpulseToVelocityA);
@@ -127,7 +127,7 @@ namespace BepuPhysics.Constraints
             LinearAxisServoFunctions.ApplyImpulse(normal, angularImpulseToVelocityA, angularImpulseToVelocityB, inertiaA, inertiaB, accumulatedImpulses, ref wsvA, ref wsvB);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref LinearAxisLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref LinearAxisLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(positionB - positionA, orientationA, orientationB, prestep.LocalPlaneNormal, prestep.LocalOffsetA, prestep.LocalOffsetB, prestep.MinimumOffset, prestep.MaximumOffset, out var error, out var normal, out var angularJA, out var angularJB);
 
@@ -146,9 +146,9 @@ namespace BepuPhysics.Constraints
             LinearAxisServoFunctions.ApplyImpulse(normal, angularImpulseToVelocityA, angularImpulseToVelocityB, inertiaA, inertiaB, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref LinearAxisLimitPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref LinearAxisLimitPrestepData prestepData) { }
     }
 
     public class LinearAxisLimitTypeProcessor : TwoBodyTypeProcessor<LinearAxisLimitPrestepData, Vector<float>, LinearAxisLimitFunctions, AccessAll, AccessAll, AccessAll, AccessAll>

--- a/BepuPhysics/Constraints/LinearAxisMotor.cs
+++ b/BepuPhysics/Constraints/LinearAxisMotor.cs
@@ -34,7 +34,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -43,8 +43,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(LinearAxisMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new LinearAxisMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(LinearAxisMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new LinearAxisMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -59,7 +59,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out LinearAxisMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out LinearAxisMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<LinearAxisMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -82,7 +82,7 @@ namespace BepuPhysics.Constraints
 
     public struct LinearAxisMotorFunctions : ITwoBodyConstraintFunctions<LinearAxisMotorPrestepData, Vector<float>>
     {
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref LinearAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref LinearAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             LinearAxisServoFunctions.ComputeJacobians(positionB - positionA, orientationA, orientationB, prestep.LocalPlaneNormal, prestep.LocalOffsetA, prestep.LocalOffsetB, out _, out var normal, out var angularJA, out var angularJB);
             Symmetric3x3Wide.TransformWithoutOverlap(angularJA, inertiaA.InverseInertiaTensor, out var angularImpulseToVelocityA);
@@ -90,7 +90,7 @@ namespace BepuPhysics.Constraints
             LinearAxisServoFunctions.ApplyImpulse(normal, angularImpulseToVelocityA, angularImpulseToVelocityB, inertiaA, inertiaB, accumulatedImpulses, ref wsvA, ref wsvB);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref LinearAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref LinearAxisMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             LinearAxisServoFunctions.ComputeJacobians(positionB - positionA, orientationA, orientationB, prestep.LocalPlaneNormal, prestep.LocalOffsetA, prestep.LocalOffsetB, out _, out var normal, out var angularJA, out var angularJB);
             MotorSettingsWide.ComputeSoftness(prestep.Settings, dt, out var effectiveMassCFMScale, out var softnessImpulseScale, out var maximumImpulse);
@@ -105,9 +105,9 @@ namespace BepuPhysics.Constraints
             LinearAxisServoFunctions.ApplyImpulse(normal, angularImpulseToVelocityA, angularImpulseToVelocityB, inertiaA, inertiaB, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref LinearAxisMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref LinearAxisMotorPrestepData prestepData) { }
     }
 
     public class LinearAxisMotorTypeProcessor : TwoBodyTypeProcessor<LinearAxisMotorPrestepData, Vector<float>, LinearAxisMotorFunctions, AccessAll, AccessAll, AccessAll, AccessAll>

--- a/BepuPhysics/Constraints/LinearAxisServo.cs
+++ b/BepuPhysics/Constraints/LinearAxisServo.cs
@@ -38,7 +38,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -47,8 +47,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(LinearAxisServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new LinearAxisServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(LinearAxisServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new LinearAxisServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -64,7 +64,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out LinearAxisServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out LinearAxisServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<LinearAxisServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -216,7 +216,7 @@ namespace BepuPhysics.Constraints
             effectiveMass = effectiveMassCFMScale / (inertiaA.InverseMass + inertiaB.InverseMass + angularContributionA + angularContributionB);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref LinearAxisServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref LinearAxisServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(positionB - positionA, orientationA, orientationB, prestep.LocalPlaneNormal, prestep.LocalOffsetA, prestep.LocalOffsetB, out _, out var normal, out var angularJA, out var angularJB);
             Symmetric3x3Wide.TransformWithoutOverlap(angularJA, inertiaA.InverseInertiaTensor, out var angularImpulseToVelocityA);
@@ -224,7 +224,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(normal, angularImpulseToVelocityA, angularImpulseToVelocityB, inertiaA, inertiaB, accumulatedImpulses, ref wsvA, ref wsvB);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref LinearAxisServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref LinearAxisServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(positionB - positionA, orientationA, orientationB, prestep.LocalPlaneNormal, prestep.LocalOffsetA, prestep.LocalOffsetB, out var planeNormalDot, out var normal, out var angularJA, out var angularJB);
             SpringSettingsWide.ComputeSpringiness(prestep.SpringSettings, dt, out var positionErrorToVelocity, out var effectiveMassCFMScale, out var softnessImpulseScale);
@@ -243,9 +243,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(normal, angularImpulseToVelocityA, angularImpulseToVelocityB, inertiaA, inertiaB, csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref LinearAxisServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref LinearAxisServoPrestepData prestepData) { }
     }
 
     public class LinearAxisServoTypeProcessor : TwoBodyTypeProcessor<LinearAxisServoPrestepData, Vector<float>, LinearAxisServoFunctions, AccessAll, AccessAll, AccessAll, AccessAll>

--- a/BepuPhysics/Constraints/OneBodyAngularMotor.cs
+++ b/BepuPhysics/Constraints/OneBodyAngularMotor.cs
@@ -22,7 +22,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -31,8 +31,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(OneBodyAngularMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new OneBodyAngularMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(OneBodyAngularMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new OneBodyAngularMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -43,7 +43,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyAngularMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyAngularMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<OneBodyAngularMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -67,12 +67,12 @@ namespace BepuPhysics.Constraints
             Vector3Wide.Add(angularVelocity, velocityChange, out angularVelocity);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyAngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyAngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             ApplyImpulse(ref wsvA.Angular, inertiaA.InverseInertiaTensor, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyAngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyAngularMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             //Jacobians are just the identity matrix.
             MotorSettingsWide.ComputeSoftness(prestep.Settings, dt, out var effectiveMassCFMScale, out var softnessImpulseScale, out var maximumImpulse);
@@ -87,9 +87,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(ref wsvA.Angular, inertiaA.InverseInertiaTensor, csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyAngularMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyAngularMotorPrestepData prestepData) { }
     }
 
     public class OneBodyAngularMotorTypeProcessor : OneBodyTypeProcessor<OneBodyAngularMotorPrestepData, Vector3Wide, OneBodyAngularMotorFunctions, AccessOnlyAngularWithoutPose, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/OneBodyAngularServo.cs
+++ b/BepuPhysics/Constraints/OneBodyAngularServo.cs
@@ -26,7 +26,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public ServoSettings ServoSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -35,8 +35,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(OneBodyAngularServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new OneBodyAngularServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(OneBodyAngularServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new OneBodyAngularServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -49,7 +49,7 @@ namespace BepuPhysics.Constraints
             ServoSettingsWide.WriteFirst(ServoSettings, ref target.ServoSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyAngularServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyAngularServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<OneBodyAngularServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -76,13 +76,13 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyAngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyAngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             ApplyImpulse(inertiaA.InverseInertiaTensor, accumulatedImpulses, ref wsvA.Angular);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyAngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyAngularServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             //Jacobians are just the identity matrix.
             QuaternionWide.Conjugate(orientationA, out var inverseOrientation);
@@ -103,9 +103,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(inertiaA.InverseInertiaTensor, csi, ref wsvA.Angular);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyAngularServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyAngularServoPrestepData prestepData) { }
     }
 
     public class OneBodyAngularServoTypeProcessor : OneBodyTypeProcessor<OneBodyAngularServoPrestepData, Vector3Wide, OneBodyAngularServoFunctions, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/OneBodyLinearMotor.cs
+++ b/BepuPhysics/Constraints/OneBodyLinearMotor.cs
@@ -26,7 +26,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -35,8 +35,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(OneBodyLinearMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new OneBodyLinearMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(OneBodyLinearMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new OneBodyLinearMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -48,7 +48,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyLinearMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyLinearMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<OneBodyLinearMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -67,13 +67,13 @@ namespace BepuPhysics.Constraints
 
     public struct OneBodyLinearMotorFunctions : IOneBodyConstraintFunctions<OneBodyLinearMotorPrestepData, Vector3Wide>
     {
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyLinearMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyLinearMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffset, orientationA, out var offset);
             OneBodyLinearServoFunctions.ApplyImpulse(offset, inertiaA, ref wsvA, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyLinearMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyLinearMotorPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffset, orientationA, out var offset);
             MotorSettingsWide.ComputeSoftness(prestep.Settings, dt, out var effectiveMassCFMScale, out var softnessImpulseScale, out var maximumImpulse);
@@ -96,9 +96,9 @@ namespace BepuPhysics.Constraints
             OneBodyLinearServoFunctions.ApplyImpulse(offset, inertiaA, ref wsvA, csi);
         }
         
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyLinearMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyLinearMotorPrestepData prestepData) { }
     }
     public class OneBodyLinearMotorTypeProcessor : OneBodyTypeProcessor<OneBodyLinearMotorPrestepData, Vector3Wide, OneBodyLinearMotorFunctions, AccessNoPosition, AccessNoPosition>
     {

--- a/BepuPhysics/Constraints/OneBodyLinearServo.cs
+++ b/BepuPhysics/Constraints/OneBodyLinearServo.cs
@@ -30,7 +30,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public ServoSettings ServoSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -39,8 +39,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(OneBodyLinearServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new OneBodyLinearServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(OneBodyLinearServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new OneBodyLinearServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -53,7 +53,7 @@ namespace BepuPhysics.Constraints
             ServoSettingsWide.WriteFirst(ServoSettings, ref target.ServoSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyLinearServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out OneBodyLinearServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<OneBodyLinearServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -105,14 +105,14 @@ namespace BepuPhysics.Constraints
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyLinearServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref OneBodyLinearServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffset, orientationA, out var offset);
             ApplyImpulse(offset, inertiaA, ref wsvA, accumulatedImpulses);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyLinearServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref OneBodyLinearServoPrestepData prestep, ref Vector3Wide accumulatedImpulses, ref BodyVelocityWide wsvA)
         {
             QuaternionWide.TransformWithoutOverlap(prestep.LocalOffset, orientationA, out var offset);
             SpringSettingsWide.ComputeSpringiness(prestep.SpringSettings, dt, out var positionErrorToVelocity, out var effectiveMassCFMScale, out var softnessImpulseScale);
@@ -141,9 +141,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(offset, inertiaA, ref wsvA, csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyLinearServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, ref OneBodyLinearServoPrestepData prestepData) { }
     }
 
     public class OneBodyLinearServoTypeProcessor : OneBodyTypeProcessor<OneBodyLinearServoPrestepData, Vector3Wide, OneBodyLinearServoFunctions, AccessAll, AccessAll>

--- a/BepuPhysics/Constraints/OneBodyTypeProcessor.cs
+++ b/BepuPhysics/Constraints/OneBodyTypeProcessor.cs
@@ -15,16 +15,16 @@ namespace BepuPhysics.Constraints
     /// <typeparam name="TAccumulatedImpulse">Type of the accumulated impulses used by the constraint.</typeparam>
     public interface IOneBodyConstraintFunctions<TPrestepData, TAccumulatedImpulse>
     {
-        void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA,
+        static abstract void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA,
             ref TPrestepData prestep, ref TAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide wsvA);
-        void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt,
+        static abstract void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt,
             ref TPrestepData prestep, ref TAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide wsvA);
 
         /// <summary>
         /// Gets whether this constraint type requires incremental updates for each substep taken beyond the first.
         /// </summary>
-        bool RequiresIncrementalSubstepUpdates { get; }
-        void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocity, ref TPrestepData prestepData);
+        static abstract bool RequiresIncrementalSubstepUpdates { get; }
+        static abstract void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocity, ref TPrestepData prestepData);
     }
 
     //Not a big fan of complex generic-filled inheritance hierarchies, but this is the shortest evolutionary step to removing duplicates.
@@ -45,7 +45,7 @@ namespace BepuPhysics.Constraints
         struct OneBodySortKeyGenerator : ISortKeyGenerator<Vector<int>>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int GetSortKey(int constraintIndex, ref Buffer<Vector<int>> bodyReferences)
+            public static int GetSortKey(int constraintIndex, ref Buffer<Vector<int>> bodyReferences)
             {
                 BundleIndexing.GetBundleIndices(constraintIndex, out var bundleIndex, out var innerIndex);
                 //We sort based on the body references within the constraint. 
@@ -88,8 +88,6 @@ namespace BepuPhysics.Constraints
             var prestepBundles = typeBatch.PrestepData.As<TPrestepData>();
             var bodyReferencesBundles = typeBatch.BodyReferences.As<Vector<int>>();
             var accumulatedImpulsesBundles = typeBatch.AccumulatedImpulses.As<TAccumulatedImpulse>();
-            var function = default(TConstraintFunctions);
-            ref var states = ref bodies.ActiveSet.DynamicsState;
             for (int i = startBundle; i < exclusiveEndBundle; ++i)
             {
                 ref var prestep = ref prestepBundles[i];
@@ -101,7 +99,7 @@ namespace BepuPhysics.Constraints
                 //if (typeof(TAllowPoseIntegration) == typeof(AllowPoseIntegration))
                 //    function.UpdateForNewPose(positionA, orientationA, inertiaA, wsvA, new Vector<float>(dt), accumulatedImpulses, ref prestep);
 
-                function.WarmStart(positionA, orientationA, inertiaA, ref prestep, ref accumulatedImpulses, ref wsvA);
+                TConstraintFunctions.WarmStart(positionA, orientationA, inertiaA, ref prestep, ref accumulatedImpulses, ref wsvA);
 
                 if (typeof(TBatchIntegrationMode) == typeof(BatchShouldNeverIntegrate))
                 {
@@ -121,8 +119,6 @@ namespace BepuPhysics.Constraints
             var prestepBundles = typeBatch.PrestepData.As<TPrestepData>();
             var bodyReferencesBundles = typeBatch.BodyReferences.As<Vector<int>>();
             var accumulatedImpulsesBundles = typeBatch.AccumulatedImpulses.As<TAccumulatedImpulse>();
-            var function = default(TConstraintFunctions);
-            ref var motionStates = ref bodies.ActiveSet.DynamicsState;
             for (int i = startBundle; i < exclusiveEndBundle; ++i)
             {
                 ref var prestep = ref prestepBundles[i];
@@ -130,25 +126,24 @@ namespace BepuPhysics.Constraints
                 ref var references = ref bodyReferencesBundles[i];
                 bodies.GatherState<TSolveAccessFilterA>(references, true, out var positionA, out var orientationA, out var wsvA, out var inertiaA);
 
-                function.Solve(positionA, orientationA, inertiaA, dt, inverseDt, ref prestep, ref accumulatedImpulses, ref wsvA);
+                TConstraintFunctions.Solve(positionA, orientationA, inertiaA, dt, inverseDt, ref prestep, ref accumulatedImpulses, ref wsvA);
 
                 bodies.ScatterVelocities<TSolveAccessFilterA>(ref wsvA, ref references);
             }
         }
 
-        public override bool RequiresIncrementalSubstepUpdates => default(TConstraintFunctions).RequiresIncrementalSubstepUpdates;
-        public unsafe override void IncrementallyUpdateForSubstep(ref TypeBatch typeBatch, Bodies bodies, float dt, float inverseDt, int startBundle, int exclusiveEndBundle)
+        public override bool RequiresIncrementalSubstepUpdates => TConstraintFunctions.RequiresIncrementalSubstepUpdates;
+        public override void IncrementallyUpdateForSubstep(ref TypeBatch typeBatch, Bodies bodies, float dt, float inverseDt, int startBundle, int exclusiveEndBundle)
         {
             var prestepBundles = typeBatch.PrestepData.As<TPrestepData>();
             var bodyReferencesBundles = typeBatch.BodyReferences.As<Vector<int>>();
-            var function = default(TConstraintFunctions);
             var dtWide = new Vector<float>(dt);
             for (int i = startBundle; i < exclusiveEndBundle; ++i)
             {
                 ref var prestep = ref prestepBundles[i];
                 ref var references = ref bodyReferencesBundles[i];
                 bodies.GatherState<AccessOnlyVelocity>(references, true, out _, out _, out var wsvA, out _);
-                function.IncrementallyUpdateForSubstep(dtWide, wsvA, ref prestep);
+                TConstraintFunctions.IncrementallyUpdateForSubstep(dtWide, wsvA, ref prestep);
             }
         }
     }

--- a/BepuPhysics/Constraints/PointOnLineServo.cs
+++ b/BepuPhysics/Constraints/PointOnLineServo.cs
@@ -34,7 +34,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -43,8 +43,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(PointOnLineServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new PointOnLineServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(PointOnLineServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new PointOnLineServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -59,7 +59,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out PointOnLineServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out PointOnLineServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<PointOnLineServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -126,13 +126,13 @@ namespace BepuPhysics.Constraints
             Vector3Wide.CrossWithoutOverlap(linearJacobian.X, offsetB, out angularJB.X);
             Vector3Wide.CrossWithoutOverlap(linearJacobian.Y, offsetB, out angularJB.Y);
         }
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref PointOnLineServoPrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref PointOnLineServoPrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobians(positionB - positionA, orientationA, orientationB, prestep.LocalDirection, prestep.LocalOffsetA, prestep.LocalOffsetB, out _, out var linearJacobian, out var angularJA, out var angularJB);
             ApplyImpulse(ref wsvA, ref wsvB, linearJacobian, angularJA, angularJB, inertiaA, inertiaB, ref accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref PointOnLineServoPrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref PointOnLineServoPrestepData prestep, ref Vector2Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //This constrains a point on B to a line attached to A. It works on two degrees of freedom at the same time; those are the tangent axes to the line direction.
             //The error is measured as closest offset from the line. In other words:
@@ -188,9 +188,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(ref wsvA, ref wsvB, linearJacobian, angularJA, angularJB, inertiaA, inertiaB, ref csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref PointOnLineServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref PointOnLineServoPrestepData prestepData) { }
     }
 
     public class PointOnLineServoTypeProcessor : TwoBodyTypeProcessor<PointOnLineServoPrestepData, Vector2Wide, PointOnLineServoFunctions, AccessAll, AccessAll, AccessAll, AccessAll>

--- a/BepuPhysics/Constraints/SwingLimit.cs
+++ b/BepuPhysics/Constraints/SwingLimit.cs
@@ -35,7 +35,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public float MaximumSwingAngle { readonly get { return (float)Math.Acos(MinimumDot); } set { MinimumDot = (float)Math.Cos(value); } }
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -44,8 +44,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(SwingLimitTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new SwingLimitTypeProcessor();
+        public static Type TypeProcessorType => typeof(SwingLimitTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new SwingLimitTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -66,7 +66,7 @@ namespace BepuPhysics.Constraints
             GetFirst(ref target.SpringSettings.TwiceDampingRatio) = SpringSettings.TwiceDampingRatio;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out SwingLimit description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out SwingLimit description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<SwingLimitPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -114,7 +114,7 @@ namespace BepuPhysics.Constraints
             var useFallback = Vector.LessThan(jacobianLengthSquared, new Vector<float>(1e-7f));
             Vector3Wide.ConditionalSelect(useFallback, fallbackJacobian, jacobianA, out jacobianA);
         }
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref SwingLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref SwingLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(prestep.AxisLocalA, prestep.AxisLocalB, orientationA, orientationB, out _, out _, out var jacobianA);
             Symmetric3x3Wide.TransformWithoutOverlap(jacobianA, inertiaA.InverseInertiaTensor, out var impulseToVelocityA);
@@ -122,7 +122,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(impulseToVelocityA, negatedImpulseToVelocityB, accumulatedImpulses, ref wsvA.Angular, ref wsvB.Angular);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref SwingLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref SwingLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //The swing limit attempts to keep an axis on body A within from an axis on body B. In other words, this is the same as a hinge joint, but with one fewer DOF.
             //(Note that the jacobians are extremely similar to the AngularSwivelHinge; the difference is that this is a speculative inequality constraint.)
@@ -164,9 +164,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(impulseToVelocityA, negatedImpulseToVelocityB, csi, ref wsvA.Angular, ref wsvB.Angular);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref SwingLimitPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref SwingLimitPrestepData prestepData) { }
     }
 
     public class SwingLimitTypeProcessor : TwoBodyTypeProcessor<SwingLimitPrestepData, Vector<float>, SwingLimitFunctions, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/SwivelHinge.cs
+++ b/BepuPhysics/Constraints/SwivelHinge.cs
@@ -34,7 +34,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -43,8 +43,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(SwivelHingeTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new SwivelHingeTypeProcessor();
+        public static Type TypeProcessorType => typeof(SwivelHingeTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new SwivelHingeTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -60,7 +60,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out SwivelHinge description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out SwivelHinge description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<SwivelHingePrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -125,14 +125,14 @@ namespace BepuPhysics.Constraints
             swivelHingeJacobian = Vector3Wide.ConditionalSelect(useFallbackJacobian, hingeAxis, swivelHingeJacobian);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref SwivelHingePrestepData prestep, ref Vector4Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref SwivelHingePrestepData prestep, ref Vector4Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(prestep.LocalOffsetA, prestep.LocalSwivelAxisA, prestep.LocalOffsetB, prestep.LocalHingeAxisB, orientationA, orientationB,
                 out _, out _, out var offsetA, out var offsetB, out var swivelHingeJacobian);
             ApplyImpulse(offsetA, offsetB, swivelHingeJacobian, inertiaA, inertiaB, ref accumulatedImpulses, ref wsvA, ref wsvB);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref SwivelHingePrestepData prestep, ref Vector4Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref SwivelHingePrestepData prestep, ref Vector4Wide accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //4x12 jacobians, from BallSocket and AngularSwivelHinge:
             //[ I, skew(offsetA),   -I, -skew(offsetB)    ]
@@ -209,9 +209,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(offsetA, offsetB, swivelHingeJacobian, inertiaA, inertiaB, ref csi, ref wsvA, ref wsvB);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref SwivelHingePrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref SwivelHingePrestepData prestepData) { }
     }
 
     public class SwivelHingeTypeProcessor : TwoBodyTypeProcessor<SwivelHingePrestepData, Vector4Wide, SwivelHingeFunctions, AccessNoPosition, AccessNoPosition, AccessAll, AccessAll>

--- a/BepuPhysics/Constraints/TwistLimit.cs
+++ b/BepuPhysics/Constraints/TwistLimit.cs
@@ -36,7 +36,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -45,8 +45,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(TwistLimitTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new TwistLimitTypeProcessor();
+        public static Type TypeProcessorType => typeof(TwistLimitTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new TwistLimitTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -62,7 +62,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TwistLimit description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TwistLimit description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<TwistLimitPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -102,7 +102,7 @@ namespace BepuPhysics.Constraints
             Vector3Wide.Negate(jacobianA, out var negatedJacobianA);
             Vector3Wide.ConditionalSelect(useMin, negatedJacobianA, jacobianA, out jacobianA);
         }
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TwistLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TwistLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(orientationA, orientationB, prestep.LocalBasisA, prestep.LocalBasisB, prestep.MinimumAngle, prestep.MaximumAngle, out _, out var jacobianA);
             Symmetric3x3Wide.TransformWithoutOverlap(jacobianA, inertiaA.InverseInertiaTensor, out var impulseToVelocityA);
@@ -110,7 +110,7 @@ namespace BepuPhysics.Constraints
             TwistServoFunctions.ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, impulseToVelocityA, negatedImpulseToVelocityB, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TwistLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TwistLimitPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(orientationA, orientationB, prestep.LocalBasisA, prestep.LocalBasisB, prestep.MinimumAngle, prestep.MaximumAngle, out var error, out var jacobianA);
 
@@ -131,9 +131,9 @@ namespace BepuPhysics.Constraints
             TwistServoFunctions.ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, impulseToVelocityA, negatedImpulseToVelocityB, csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TwistLimitPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TwistLimitPrestepData prestepData) { }
     }
 
     public class TwistLimitTypeProcessor : TwoBodyTypeProcessor<TwistLimitPrestepData, Vector<float>, TwistLimitFunctions, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/TwistMotor.cs
+++ b/BepuPhysics/Constraints/TwistMotor.cs
@@ -30,7 +30,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public MotorSettings Settings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -39,8 +39,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(TwistMotorTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new TwistMotorTypeProcessor();
+        public static Type TypeProcessorType => typeof(TwistMotorTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new TwistMotorTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -55,7 +55,7 @@ namespace BepuPhysics.Constraints
             MotorSettingsWide.WriteFirst(Settings, ref target.Settings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TwistMotor description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TwistMotor description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<TwistMotorPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -88,7 +88,7 @@ namespace BepuPhysics.Constraints
             Vector3Wide.ConditionalSelect(Vector.LessThan(length, new Vector<float>(1e-10f)), axisA, jacobianA, out jacobianA);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TwistMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TwistMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(orientationA, orientationB, prestep.LocalAxisA, prestep.LocalAxisB, out var jacobianA);
             Symmetric3x3Wide.TransformWithoutOverlap(jacobianA, inertiaA.InverseInertiaTensor, out var impulseToVelocityA);
@@ -96,7 +96,7 @@ namespace BepuPhysics.Constraints
             TwistServoFunctions.ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, impulseToVelocityA, negatedImpulseToVelocityB, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TwistMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TwistMotorPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(orientationA, orientationB, prestep.LocalAxisA, prestep.LocalAxisB, out var jacobianA);
 
@@ -120,9 +120,9 @@ namespace BepuPhysics.Constraints
             TwistServoFunctions.ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, impulseToVelocityA, negatedImpulseToVelocityB, csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TwistMotorPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TwistMotorPrestepData prestepData) { }
     }
 
     public class TwistMotorTypeProcessor : TwoBodyTypeProcessor<TwistMotorPrestepData, Vector<float>, TwistMotorFunctions, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/TwistServo.cs
+++ b/BepuPhysics/Constraints/TwistServo.cs
@@ -36,7 +36,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public ServoSettings ServoSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -45,8 +45,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(TwistServoTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new TwistServoTypeProcessor();
+        public static Type TypeProcessorType => typeof(TwistServoTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new TwistServoTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -62,7 +62,7 @@ namespace BepuPhysics.Constraints
             ServoSettingsWide.WriteFirst(ServoSettings, ref target.ServoSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TwistServo description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out TwistServo description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<TwistServoPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -181,7 +181,7 @@ namespace BepuPhysics.Constraints
             Vector3Wide.ConditionalSelect(Vector.LessThan(length, new Vector<float>(1e-10f)), basisAZ, jacobianA, out jacobianA);
         }
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TwistServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref TwistServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(orientationA, orientationB, prestep.LocalBasisA, prestep.LocalBasisB, out var jacobianA);
             Symmetric3x3Wide.TransformWithoutOverlap(jacobianA, inertiaA.InverseInertiaTensor, out var impulseToVelocityA);
@@ -189,7 +189,7 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, impulseToVelocityA, negatedImpulseToVelocityB, accumulatedImpulses);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TwistServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref TwistServoPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             ComputeJacobian(orientationA, orientationB, prestep.LocalBasisA, prestep.LocalBasisB,
                 out var basisBX, out var basisBZ, out var basisA, out var jacobianA);
@@ -216,9 +216,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(ref wsvA.Angular, ref wsvB.Angular, impulseToVelocityA, negatedImpulseToVelocityB, csi);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TwistServoPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref TwistServoPrestepData prestepData) { }
     }
 
     public class TwistServoTypeProcessor : TwoBodyTypeProcessor<TwistServoPrestepData, Vector<float>, TwistServoFunctions, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular, AccessOnlyAngular>

--- a/BepuPhysics/Constraints/VolumeConstraint.cs
+++ b/BepuPhysics/Constraints/VolumeConstraint.cs
@@ -38,7 +38,7 @@ namespace BepuPhysics.Constraints
             SpringSettings = springSettings;
         }
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -47,8 +47,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(VolumeConstraintTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new VolumeConstraintTypeProcessor();
+        public static Type TypeProcessorType => typeof(VolumeConstraintTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new VolumeConstraintTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -59,7 +59,7 @@ namespace BepuPhysics.Constraints
             SpringSettingsWide.WriteFirst(SpringSettings, ref target.SpringSettings);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out VolumeConstraint description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out VolumeConstraint description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<VolumeConstraintPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -106,14 +106,14 @@ namespace BepuPhysics.Constraints
             Vector3Wide.Add(jacobianB, jacobianC, out negatedJA);
             Vector3Wide.Add(jacobianD, negatedJA, out negatedJA);
         }
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC, in Vector3Wide positionD, in QuaternionWide orientationD, in BodyInertiaWide inertiaD, ref VolumeConstraintPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB, ref BodyVelocityWide wsvC, ref BodyVelocityWide wsvD)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC, in Vector3Wide positionD, in QuaternionWide orientationD, in BodyInertiaWide inertiaD, ref VolumeConstraintPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB, ref BodyVelocityWide wsvC, ref BodyVelocityWide wsvD)
         {
             ComputeJacobian(positionA, positionB, positionC, positionD, out var ad, out var negatedJA, out var jacobianB, out var jacobianC, out var jacobianD);
             //Vector3Wide.Dot(jacobianD, ad, out var unscaledVolume);
             ApplyImpulse(inertiaA.InverseMass, inertiaB.InverseMass, inertiaC.InverseMass, inertiaD.InverseMass, negatedJA, jacobianB, jacobianC, jacobianD, accumulatedImpulses, ref wsvA, ref wsvB, ref wsvC, ref wsvD);
         }
 
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC, in Vector3Wide positionD, in QuaternionWide orientationD, in BodyInertiaWide inertiaD, float dt, float inverseDt, ref VolumeConstraintPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB, ref BodyVelocityWide wsvC, ref BodyVelocityWide wsvD)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, in Vector3Wide positionC, in QuaternionWide orientationC, in BodyInertiaWide inertiaC, in Vector3Wide positionD, in QuaternionWide orientationD, in BodyInertiaWide inertiaD, float dt, float inverseDt, ref VolumeConstraintPrestepData prestep, ref Vector<float> accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB, ref BodyVelocityWide wsvC, ref BodyVelocityWide wsvD)
         {
             //Volume of parallelepiped with vertices a, b, c, d is:
             //(ab x ac) * ad
@@ -173,9 +173,9 @@ namespace BepuPhysics.Constraints
             ApplyImpulse(inertiaA.InverseMass, inertiaB.InverseMass, inertiaC.InverseMass, inertiaD.InverseMass, negatedJA, jacobianB, jacobianC, jacobianD, csi, ref wsvA, ref wsvB, ref wsvC, ref wsvD);
         }
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, in BodyVelocityWide wsvC, in BodyVelocityWide wsvD, ref VolumeConstraintPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, in BodyVelocityWide wsvC, in BodyVelocityWide wsvD, ref VolumeConstraintPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/Constraints/Weld.cs
+++ b/BepuPhysics/Constraints/Weld.cs
@@ -33,7 +33,7 @@ namespace BepuPhysics.Constraints
         /// </summary>
         public SpringSettings SpringSettings;
 
-        public readonly int ConstraintTypeId
+        public static int ConstraintTypeId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -42,8 +42,8 @@ namespace BepuPhysics.Constraints
             }
         }
 
-        public readonly Type TypeProcessorType => typeof(WeldTypeProcessor);
-        public readonly TypeProcessor CreateTypeProcessor() => new WeldTypeProcessor();
+        public static Type TypeProcessorType => typeof(WeldTypeProcessor);
+        public static TypeProcessor CreateTypeProcessor() => new WeldTypeProcessor();
 
         public readonly void ApplyDescription(ref TypeBatch batch, int bundleIndex, int innerIndex)
         {
@@ -58,7 +58,7 @@ namespace BepuPhysics.Constraints
             GetFirst(ref target.SpringSettings.TwiceDampingRatio) = SpringSettings.TwiceDampingRatio;
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Weld description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out Weld description)
         {
             Debug.Assert(ConstraintTypeId == batch.TypeId, "The type batch passed to the description must match the description's expected type.");
             ref var source = ref GetOffsetInstance(ref Buffer<WeldPrestepData>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
@@ -114,14 +114,14 @@ namespace BepuPhysics.Constraints
         }
 
         //[MethodImpl(MethodImplOptions.NoInlining)]
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB,
             ref WeldPrestepData prestep, ref WeldAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             Transform(prestep.LocalOffset, orientationA, out var offset);
             ApplyImpulse(inertiaA, inertiaB, offset, accumulatedImpulses.Orientation, accumulatedImpulses.Offset, ref wsvA, ref wsvB);
         }
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt,
             ref WeldPrestepData prestep, ref WeldAccumulatedImpulses accumulatedImpulses, ref BodyVelocityWide wsvA, ref BodyVelocityWide wsvB)
         {
             //The weld constraint handles 6 degrees of freedom simultaneously. The constraints are:
@@ -211,9 +211,9 @@ namespace BepuPhysics.Constraints
         }
 
 
-        public bool RequiresIncrementalSubstepUpdates => false;
+        public static bool RequiresIncrementalSubstepUpdates => false;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref WeldPrestepData prestepData) { }
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide wsvA, in BodyVelocityWide wsvB, ref WeldPrestepData prestepData) { }
     }
 
 

--- a/BepuPhysics/SequentialFallbackBatch.cs
+++ b/BepuPhysics/SequentialFallbackBatch.cs
@@ -13,13 +13,13 @@ namespace BepuPhysics
 {
     interface IBodyReferenceGetter
     {
-        int GetBodyReference(Bodies bodies, BodyHandle handle);
+        static abstract int GetBodyReference(Bodies bodies, BodyHandle handle);
     }
 
     struct ActiveSetGetter : IBodyReferenceGetter
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetBodyReference(Bodies bodies, BodyHandle bodyHandle)
+        public static int GetBodyReference(Bodies bodies, BodyHandle bodyHandle)
         {
             ref var bodyLocation = ref bodies.HandleToLocation[bodyHandle.Value];
             Debug.Assert(bodyLocation.SetIndex == 0, "When creating a fallback batch for the active set, all bodies associated with it must be active.");
@@ -29,7 +29,7 @@ namespace BepuPhysics
     struct InactiveSetGetter : IBodyReferenceGetter
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetBodyReference(Bodies bodies, BodyHandle bodyHandle)
+        public static int GetBodyReference(Bodies bodies, BodyHandle bodyHandle)
         {
             return bodyHandle.Value;
         }
@@ -44,7 +44,7 @@ namespace BepuPhysics
         /// <summary>
         /// Gets the number of bodies in the fallback batch.
         /// </summary>
-        public readonly int BodyCount { get { return dynamicBodyConstraintCounts.Count; } }
+        public int BodyCount { get { return dynamicBodyConstraintCounts.Count; } }
 
         //In order to maintain the batch referenced handles for the fallback batch (which can have the same body appear more than once),
         //every body must maintain a count of fallback constraints associated with it.
@@ -60,7 +60,7 @@ namespace BepuPhysics
             EnsureCapacity(Math.Max(dynamicBodyConstraintCounts.Count + dynamicBodyHandles.Length, minimumBodyCapacity), pool);
             for (int i = 0; i < dynamicBodyHandles.Length; ++i)
             {
-                var bodyReference = bodyReferenceGetter.GetBodyReference(bodies, dynamicBodyHandles[i]);
+                var bodyReference = TBodyReferenceGetter.GetBodyReference(bodies, dynamicBodyHandles[i]);
 
                 if (dynamicBodyConstraintCounts.FindOrAllocateSlotUnsafely(bodyReference, out var slotIndex))
                 {

--- a/BepuPhysics/Simulation_Queries.cs
+++ b/BepuPhysics/Simulation_Queries.cs
@@ -193,7 +193,7 @@ namespace BepuPhysics
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void Test(CollidableReference reference, ref float maximumT)
+            public void Test(CollidableReference reference, ref float maximumT)
             {
                 if (HitHandler.AllowTest(reference))
                 {
@@ -277,7 +277,7 @@ namespace BepuPhysics
             dispatcher.Velocity = velocity;
             //Note that the shape was passed by copy, and that all shape types are required to be blittable. No GC hole.
             dispatcher.ShapeData = &shape;
-            dispatcher.ShapeType = shape.TypeId;
+            dispatcher.ShapeType = TShape.TypeId;
             dispatcher.Simulation = this;
             dispatcher.Pool = pool;
             dispatcher.CollidableBeingTested = default;

--- a/DemoBenchmarks/ConvexCollisionTesterBenchmarks.cs
+++ b/DemoBenchmarks/ConvexCollisionTesterBenchmarks.cs
@@ -91,33 +91,30 @@ public class ConvexCollisionTesterBenchmarks
 
     Vector<float> TestOrientationless1Contact<TTester, TShapeA, TShapeB>(TShapeA a, TShapeB b) where TTester : unmanaged, IPairTester<TShapeA, TShapeB, Convex1ContactManifoldWide>
     {
-        var tester = default(TTester);
         Vector<float> testSum = Vector<float>.Zero;
         for (int i = 0; i < iterationCount; ++i)
         {
-            tester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], Vector<float>.Count, out var manifold);
+            TTester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], Vector<float>.Count, out var manifold);
             testSum += manifold.Depth + manifold.Normal.X + manifold.Normal.Y + manifold.Normal.Z + manifold.OffsetA.X + manifold.OffsetA.Y + manifold.OffsetA.Z;
         }
         return testSum;
     }
     Vector<float> TestOrientationB1Contact<TTester, TShapeA, TShapeB>(TShapeA a, TShapeB b) where TTester : unmanaged, IPairTester<TShapeA, TShapeB, Convex1ContactManifoldWide>
     {
-        var tester = default(TTester);
         Vector<float> testSum = Vector<float>.Zero;
         for (int i = 0; i < iterationCount; ++i)
         {
-            tester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], ref orientationsB[i], Vector<float>.Count, out var manifold);
+            TTester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], ref orientationsB[i], Vector<float>.Count, out var manifold);
             testSum += manifold.Depth + manifold.Normal.X + manifold.Normal.Y + manifold.Normal.Z + manifold.OffsetA.X + manifold.OffsetA.Y + manifold.OffsetA.Z;
         }
         return testSum;
     }
     Vector<float> Test2Contact<TTester, TShapeA, TShapeB>(TShapeA a, TShapeB b) where TTester : unmanaged, IPairTester<TShapeA, TShapeB, Convex2ContactManifoldWide>
     {
-        var tester = default(TTester);
         Vector<float> testSum = Vector<float>.Zero;
         for (int i = 0; i < iterationCount; ++i)
         {
-            tester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], ref orientationsA[i], ref orientationsB[i], Vector<float>.Count, out var manifold);
+            TTester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], ref orientationsA[i], ref orientationsB[i], Vector<float>.Count, out var manifold);
             testSum += manifold.Normal.X + manifold.Normal.Y + manifold.Normal.Z +
                 manifold.OffsetA0.X + manifold.OffsetA0.Y + manifold.OffsetA0.Z + manifold.Depth0 +
                 manifold.OffsetA1.X + manifold.OffsetA1.Y + manifold.OffsetA1.Z + manifold.Depth1;
@@ -126,11 +123,10 @@ public class ConvexCollisionTesterBenchmarks
     }
     Vector<float> Test4Contact<TTester, TShapeA, TShapeB>(TShapeA a, TShapeB b) where TTester : unmanaged, IPairTester<TShapeA, TShapeB, Convex4ContactManifoldWide>
     {
-        var tester = default(TTester);
         Vector<float> testSum = Vector<float>.Zero;
         for (int i = 0; i < iterationCount; ++i)
         {
-            tester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], ref orientationsA[i], ref orientationsB[i], Vector<float>.Count, out var manifold);
+            TTester.Test(ref a, ref b, ref speculativeMargins[i], ref offsetsB[i], ref orientationsA[i], ref orientationsB[i], Vector<float>.Count, out var manifold);
             testSum += manifold.Normal.X + manifold.Normal.Y + manifold.Normal.Z +
                 manifold.OffsetA0.X + manifold.OffsetA0.Y + manifold.OffsetA0.Z + manifold.Depth0 +
                 manifold.OffsetA1.X + manifold.OffsetA1.Y + manifold.OffsetA1.Z + manifold.Depth1 +

--- a/DemoBenchmarks/FourBodyConstraintBenchmarks.cs
+++ b/DemoBenchmarks/FourBodyConstraintBenchmarks.cs
@@ -23,7 +23,6 @@ public class FourBodyConstraintBenchmarks
         Vector3Wide positionD, QuaternionWide orientationD, BodyInertiaWide inertiaD, TPrestep prestep)
         where TConstraintFunctions : unmanaged, IFourBodyConstraintFunctions<TPrestep, TAccumulatedImpulse> where TPrestep : unmanaged where TAccumulatedImpulse : unmanaged
     {
-        var functions = default(TConstraintFunctions);
         var accumulatedImpulse = default(TAccumulatedImpulse);
         var velocityA = default(BodyVelocityWide);
         var velocityB = default(BodyVelocityWide);
@@ -35,9 +34,9 @@ public class FourBodyConstraintBenchmarks
         const float dt = 1f / inverseDt;
         for (int i = 0; i < iterations; ++i)
         {
-            functions.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD,
+            TConstraintFunctions.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD,
                 ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB, ref velocityC, ref velocityD);
-            functions.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD, dt, inverseDt,
+            TConstraintFunctions.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, positionD, orientationD, inertiaD, dt, inverseDt,
                 ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB, ref velocityC, ref velocityD);
         }
         return (velocityA, velocityB, velocityC, velocityD);

--- a/DemoBenchmarks/OneBodyConstraintBenchmarks.cs
+++ b/DemoBenchmarks/OneBodyConstraintBenchmarks.cs
@@ -19,7 +19,6 @@ public class OneBodyConstraintBenchmarks
     public static BodyVelocityWide BenchmarkOneBodyConstraint<TConstraintFunctions, TPrestep, TAccumulatedImpulse>(Vector3Wide positionA, QuaternionWide orientationA, BodyInertiaWide inertiaA, TPrestep prestep)
         where TConstraintFunctions : unmanaged, IOneBodyConstraintFunctions<TPrestep, TAccumulatedImpulse> where TPrestep : unmanaged where TAccumulatedImpulse : unmanaged
     {
-        var functions = default(TConstraintFunctions);
         var accumulatedImpulse = default(TAccumulatedImpulse);
         var velocityA = default(BodyVelocityWide);
         //Individual constraint iterations are often extremely cheap, so beef the benchmark up a bit.
@@ -28,8 +27,8 @@ public class OneBodyConstraintBenchmarks
         const float dt = 1f / inverseDt;
         for (int i = 0; i < iterations; ++i)
         {
-            functions.WarmStart(positionA, orientationA, inertiaA, ref prestep, ref accumulatedImpulse, ref velocityA);
-            functions.Solve(positionA, orientationA, inertiaA, dt, inverseDt, ref prestep, ref accumulatedImpulse, ref velocityA);
+            TConstraintFunctions.WarmStart(positionA, orientationA, inertiaA, ref prestep, ref accumulatedImpulse, ref velocityA);
+            TConstraintFunctions.Solve(positionA, orientationA, inertiaA, dt, inverseDt, ref prestep, ref accumulatedImpulse, ref velocityA);
         }
         return velocityA;
     }

--- a/DemoBenchmarks/ShapeRayBenchmarksDeep.cs
+++ b/DemoBenchmarks/ShapeRayBenchmarksDeep.cs
@@ -82,7 +82,7 @@ public class ShapeRayBenchmarksDeep
         {
             ref var iteration = ref iterations[i];
             float maximumT = float.MaxValue;
-            shapes[default(TShape).TypeId].RayTest(0, iteration.Pose, iteration.Ray, ref maximumT, ref hitHandler);
+            shapes[TShape.TypeId].RayTest(0, iteration.Pose, iteration.Ray, ref maximumT, ref hitHandler);
         }
         return hitHandler.ResultSum;
     }

--- a/DemoBenchmarks/SweepBenchmarks.cs
+++ b/DemoBenchmarks/SweepBenchmarks.cs
@@ -122,8 +122,8 @@ public class Sweeper
     public unsafe Vector3 Test<TA, TB>() where TA : unmanaged, IShape where TB : unmanaged, IShape
     {
         var task = taskRegistry.GetTask<TA, TB>();
-        var aType = default(TA).TypeId;
-        var bType = default(TB).TypeId;
+        var aType = TA.TypeId;
+        var bType = TB.TypeId;
         shapes[aType].GetShapeData(0, out var aData, out _);
         shapes[bType].GetShapeData(0, out var bData, out _);
         var filter = default(Filter);

--- a/DemoBenchmarks/ThreeBodyConstraintBenchmarks.cs
+++ b/DemoBenchmarks/ThreeBodyConstraintBenchmarks.cs
@@ -22,7 +22,6 @@ public class ThreeBodyConstraintBenchmarks
         Vector3Wide positionC, QuaternionWide orientationC, BodyInertiaWide inertiaC, TPrestep prestep)
         where TConstraintFunctions : unmanaged, IThreeBodyConstraintFunctions<TPrestep, TAccumulatedImpulse> where TPrestep : unmanaged where TAccumulatedImpulse : unmanaged
     {
-        var functions = default(TConstraintFunctions);
         var accumulatedImpulse = default(TAccumulatedImpulse);
         var velocityA = default(BodyVelocityWide);
         var velocityB = default(BodyVelocityWide);
@@ -33,8 +32,8 @@ public class ThreeBodyConstraintBenchmarks
         const float dt = 1f / inverseDt;
         for (int i = 0; i < iterations; ++i)
         {
-            functions.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB, ref velocityC);
-            functions.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, dt, inverseDt, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB, ref velocityC);
+            TConstraintFunctions.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB, ref velocityC);
+            TConstraintFunctions.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, positionC, orientationC, inertiaC, dt, inverseDt, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB, ref velocityC);
         }
         return (velocityA, velocityB, velocityC);
     }

--- a/DemoBenchmarks/TwoBodyConstraintBenchmarks.cs
+++ b/DemoBenchmarks/TwoBodyConstraintBenchmarks.cs
@@ -21,7 +21,6 @@ public class TwoBodyConstraintBenchmarks
         Vector3Wide positionB, QuaternionWide orientationB, BodyInertiaWide inertiaB, TPrestep prestep)
         where TConstraintFunctions : unmanaged, ITwoBodyConstraintFunctions<TPrestep, TAccumulatedImpulse> where TPrestep : unmanaged where TAccumulatedImpulse : unmanaged
     {
-        var functions = default(TConstraintFunctions);
         var accumulatedImpulse = default(TAccumulatedImpulse);
         var velocityA = default(BodyVelocityWide);
         var velocityB = default(BodyVelocityWide);
@@ -31,8 +30,8 @@ public class TwoBodyConstraintBenchmarks
         const float dt = 1f / inverseDt;
         for (int i = 0; i < iterations; ++i)
         {
-            functions.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB);
-            functions.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, dt, inverseDt, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB);
+            TConstraintFunctions.WarmStart(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB);
+            TConstraintFunctions.Solve(positionA, orientationA, inertiaA, positionB, orientationB, inertiaB, dt, inverseDt, ref prestep, ref accumulatedImpulse, ref velocityA, ref velocityB);
         }
         return (velocityA, velocityB);
     }

--- a/DemoRenderer.GL/ShapeDrawing/ShapesExtractor.cs
+++ b/DemoRenderer.GL/ShapeDrawing/ShapesExtractor.cs
@@ -276,7 +276,7 @@ namespace DemoRenderer.ShapeDrawing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void AddShape<TShape>(TShape shape, Shapes shapes, RigidPose pose, Vector3 color) where TShape : IShape
         {
-            AddShape(Unsafe.AsPointer(ref shape), shape.TypeId, shapes, pose, color, ref ShapeCache, pool);
+            AddShape(Unsafe.AsPointer(ref shape), TShape.TypeId, shapes, pose, color, ref ShapeCache, pool);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/DemoRenderer/Constraints/AngularSwivelHingeLineExtractor.cs
+++ b/DemoRenderer/Constraints/AngularSwivelHingeLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct AngularSwivelHingeLineExtractor : IConstraintLineExtractor<AngularSwivelHingePrestepData>
     {
-        public int LinesPerConstraint => 2;
+        public static int LinesPerConstraint => 2;
         
-        public unsafe void ExtractLines(ref AngularSwivelHingePrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref AngularSwivelHingePrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/BallSocketLineExtractor.cs
+++ b/DemoRenderer/Constraints/BallSocketLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct BallSocketLineExtractor : IConstraintLineExtractor<BallSocketPrestepData>
     {
-        public int LinesPerConstraint => 3;
+        public static int LinesPerConstraint => 3;
 
-        public unsafe void ExtractLines(ref BallSocketPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref BallSocketPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/BallSocketMotorLineExtractor.cs
+++ b/DemoRenderer/Constraints/BallSocketMotorLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct BallSocketMotorLineExtractor : IConstraintLineExtractor<BallSocketMotorPrestepData>
     {
-        public int LinesPerConstraint => 2;
+        public static int LinesPerConstraint => 2;
 
-        public unsafe void ExtractLines(ref BallSocketMotorPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref BallSocketMotorPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/BallSocketServoLineExtractor.cs
+++ b/DemoRenderer/Constraints/BallSocketServoLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct BallSocketServoLineExtractor : IConstraintLineExtractor<BallSocketServoPrestepData>
     {
-        public int LinesPerConstraint => 3;
+        public static int LinesPerConstraint => 3;
 
-        public unsafe void ExtractLines(ref BallSocketServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref BallSocketServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/CenterDistanceLimitLineExtractor.cs
+++ b/DemoRenderer/Constraints/CenterDistanceLimitLineExtractor.cs
@@ -9,9 +9,9 @@ namespace DemoRenderer.Constraints
 {
     struct CenterDistanceLimitLineExtractor : IConstraintLineExtractor<CenterDistanceLimitPrestepData>
     {
-        public int LinesPerConstraint => 5;
+        public static int LinesPerConstraint => 5;
 
-        public unsafe void ExtractLines(ref CenterDistanceLimitPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref CenterDistanceLimitPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/CenterDistanceLineExtractor.cs
+++ b/DemoRenderer/Constraints/CenterDistanceLineExtractor.cs
@@ -9,9 +9,9 @@ namespace DemoRenderer.Constraints
 {
     struct CenterDistanceLineExtractor : IConstraintLineExtractor<CenterDistancePrestepData>
     {
-        public int LinesPerConstraint => 2;
+        public static int LinesPerConstraint => 2;
 
-        public unsafe void ExtractLines(ref CenterDistancePrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref CenterDistancePrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/ConstraintLineExtractor.cs
+++ b/DemoRenderer/Constraints/ConstraintLineExtractor.cs
@@ -16,9 +16,9 @@ namespace DemoRenderer.Constraints
 {
     unsafe interface IConstraintLineExtractor<TPrestep>
     {
-        int LinesPerConstraint { get; }
+        static abstract int LinesPerConstraint { get; }
 
-        void ExtractLines(ref TPrestep prestepBundle, int setIndex, int* bodyLocations, Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines);
+        static abstract void ExtractLines(ref TPrestep prestepBundle, int setIndex, int* bodyLocations, Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines);
     }
     abstract class TypeLineExtractor
     {
@@ -31,7 +31,7 @@ namespace DemoRenderer.Constraints
         where TPrestep : unmanaged
         where T : struct, IConstraintLineExtractor<TPrestep>
     {
-        public override int LinesPerConstraint => default(T).LinesPerConstraint;
+        public override int LinesPerConstraint => T.LinesPerConstraint;
         public unsafe override void ExtractLines(Bodies bodies, int setIndex, ref TypeBatch typeBatch, int constraintStart, int constraintCount,
             ref QuickList<LineInstance> lines)
         {
@@ -42,7 +42,6 @@ namespace DemoRenderer.Constraints
             var bodyCount = Unsafe.SizeOf<TBodyReferences>() / Unsafe.SizeOf<Vector<int>>();
             Debug.Assert(bodyCount * Unsafe.SizeOf<Vector<int>>() == Unsafe.SizeOf<TBodyReferences>());
             var bodyIndices = stackalloc int[bodyCount];
-            var extractor = default(T);
 
             var constraintEnd = constraintStart + constraintCount;
             if (setIndex == 0)
@@ -61,7 +60,7 @@ namespace DemoRenderer.Constraints
                             //Active set constraint body references refer directly to the body index.
                             bodyIndices[j] = GatherScatter.Get(ref Unsafe.Add(ref firstReference, j), innerIndex) & Bodies.BodyReferenceMask;
                         }
-                        extractor.ExtractLines(ref GatherScatter.GetOffsetInstance(ref prestepBundle, innerIndex), setIndex, bodyIndices, bodies, ref tint, ref lines);
+                        T.ExtractLines(ref GatherScatter.GetOffsetInstance(ref prestepBundle, innerIndex), setIndex, bodyIndices, bodies, ref tint, ref lines);
                     }
                 }
             }
@@ -83,7 +82,7 @@ namespace DemoRenderer.Constraints
                             Debug.Assert(bodies.HandleToLocation[bodyHandle].SetIndex == setIndex);
                             bodyIndices[j] = bodies.HandleToLocation[bodyHandle].Index & Bodies.BodyReferenceMask;
                         }
-                        extractor.ExtractLines(ref GatherScatter.GetOffsetInstance(ref prestepBundle, innerIndex), setIndex, bodyIndices, bodies, ref tint, ref lines);
+                        T.ExtractLines(ref GatherScatter.GetOffsetInstance(ref prestepBundle, innerIndex), setIndex, bodyIndices, bodies, ref tint, ref lines);
                     }
                 }
             }

--- a/DemoRenderer/Constraints/ContactLineExtractors.cs
+++ b/DemoRenderer/Constraints/ContactLineExtractors.cs
@@ -9,9 +9,9 @@ namespace BepuPhysics.Constraints.Contact
 {  
     struct Contact1OneBodyLineExtractor : IConstraintLineExtractor<Contact1OneBodyPrestepData>
     {
-        public int LinesPerConstraint => 2;
+        public static int LinesPerConstraint => 2;
 
-        public unsafe void ExtractLines(ref Contact1OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact1OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -20,9 +20,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact2OneBodyLineExtractor : IConstraintLineExtractor<Contact2OneBodyPrestepData>
     {
-        public int LinesPerConstraint => 4;
+        public static int LinesPerConstraint => 4;
 
-        public unsafe void ExtractLines(ref Contact2OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact2OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -32,9 +32,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact3OneBodyLineExtractor : IConstraintLineExtractor<Contact3OneBodyPrestepData>
     {
-        public int LinesPerConstraint => 6;
+        public static int LinesPerConstraint => 6;
 
-        public unsafe void ExtractLines(ref Contact3OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact3OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -45,9 +45,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact4OneBodyLineExtractor : IConstraintLineExtractor<Contact4OneBodyPrestepData>
     {
-        public int LinesPerConstraint => 8;
+        public static int LinesPerConstraint => 8;
 
-        public unsafe void ExtractLines(ref Contact4OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact4OneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -59,9 +59,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact1LineExtractor : IConstraintLineExtractor<Contact1PrestepData>
     {
-        public int LinesPerConstraint => 2;
+        public static int LinesPerConstraint => 2;
 
-        public unsafe void ExtractLines(ref Contact1PrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact1PrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -70,9 +70,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact2LineExtractor : IConstraintLineExtractor<Contact2PrestepData>
     {
-        public int LinesPerConstraint => 4;
+        public static int LinesPerConstraint => 4;
 
-        public unsafe void ExtractLines(ref Contact2PrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact2PrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -82,9 +82,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact3LineExtractor : IConstraintLineExtractor<Contact3PrestepData>
     {
-        public int LinesPerConstraint => 6;
+        public static int LinesPerConstraint => 6;
 
-        public unsafe void ExtractLines(ref Contact3PrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact3PrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -95,9 +95,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact4LineExtractor : IConstraintLineExtractor<Contact4PrestepData>
     {
-        public int LinesPerConstraint => 8;
+        public static int LinesPerConstraint => 8;
 
-        public unsafe void ExtractLines(ref Contact4PrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact4PrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -109,9 +109,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact2NonconvexOneBodyLineExtractor : IConstraintLineExtractor<Contact2NonconvexOneBodyPrestepData>
     {
-        public int LinesPerConstraint => 4;
+        public static int LinesPerConstraint => 4;
 
-        public unsafe void ExtractLines(ref Contact2NonconvexOneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact2NonconvexOneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -121,9 +121,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact3NonconvexOneBodyLineExtractor : IConstraintLineExtractor<Contact3NonconvexOneBodyPrestepData>
     {
-        public int LinesPerConstraint => 6;
+        public static int LinesPerConstraint => 6;
 
-        public unsafe void ExtractLines(ref Contact3NonconvexOneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact3NonconvexOneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -134,9 +134,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact4NonconvexOneBodyLineExtractor : IConstraintLineExtractor<Contact4NonconvexOneBodyPrestepData>
     {
-        public int LinesPerConstraint => 8;
+        public static int LinesPerConstraint => 8;
 
-        public unsafe void ExtractLines(ref Contact4NonconvexOneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact4NonconvexOneBodyPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -148,9 +148,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact2NonconvexLineExtractor : IConstraintLineExtractor<Contact2NonconvexPrestepData>
     {
-        public int LinesPerConstraint => 4;
+        public static int LinesPerConstraint => 4;
 
-        public unsafe void ExtractLines(ref Contact2NonconvexPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact2NonconvexPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -160,9 +160,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact3NonconvexLineExtractor : IConstraintLineExtractor<Contact3NonconvexPrestepData>
     {
-        public int LinesPerConstraint => 6;
+        public static int LinesPerConstraint => 6;
 
-        public unsafe void ExtractLines(ref Contact3NonconvexPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact3NonconvexPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;
@@ -173,9 +173,9 @@ namespace BepuPhysics.Constraints.Contact
     }
     struct Contact4NonconvexLineExtractor : IConstraintLineExtractor<Contact4NonconvexPrestepData>
     {
-        public int LinesPerConstraint => 8;
+        public static int LinesPerConstraint => 8;
 
-        public unsafe void ExtractLines(ref Contact4NonconvexPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact4NonconvexPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].DynamicsState[bodyIndices[0]].Motion.Pose;

--- a/DemoRenderer/Constraints/ContactLineExtractors.tt
+++ b/DemoRenderer/Constraints/ContactLineExtractors.tt
@@ -26,9 +26,9 @@ for (int convexity = 0; convexity <= 1; ++convexity)
 #>
     struct Contact<#=contactCount#><#=convexitySuffix#><#=bodySuffix#>LineExtractor : IConstraintLineExtractor<Contact<#=contactCount#><#=convexitySuffix#><#=bodySuffix#>PrestepData>
     {
-        public int LinesPerConstraint => <#=contactCount * 2#>;
+        public static int LinesPerConstraint => <#=contactCount * 2#>;
 
-        public unsafe void ExtractLines(ref Contact<#=contactCount#><#=convexitySuffix#><#=bodySuffix#>PrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref Contact<#=contactCount#><#=convexitySuffix#><#=bodySuffix#>PrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             ref var poseA = ref bodies.Sets[setIndex].SolverStates[bodyIndices[0]].Motion.Pose;

--- a/DemoRenderer/Constraints/DistanceLimitLineExtractor.cs
+++ b/DemoRenderer/Constraints/DistanceLimitLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct DistanceLimitLineExtractor : IConstraintLineExtractor<DistanceLimitPrestepData>
     {
-        public int LinesPerConstraint => 5;
+        public static int LinesPerConstraint => 5;
 
-        public unsafe void ExtractLines(ref DistanceLimitPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref DistanceLimitPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/DistanceServoLineExtractor.cs
+++ b/DemoRenderer/Constraints/DistanceServoLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct DistanceServoLineExtractor : IConstraintLineExtractor<DistanceServoPrestepData>
     {
-        public int LinesPerConstraint => 4;
+        public static int LinesPerConstraint => 4;
 
-        public unsafe void ExtractLines(ref DistanceServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref DistanceServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/HingeLineExtractor.cs
+++ b/DemoRenderer/Constraints/HingeLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct HingeLineExtractor : IConstraintLineExtractor<HingePrestepData>
     {
-        public int LinesPerConstraint => 4;
+        public static int LinesPerConstraint => 4;
 
-        public unsafe void ExtractLines(ref HingePrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref HingePrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/LinearAxisServoLineExtractor.cs
+++ b/DemoRenderer/Constraints/LinearAxisServoLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct LinearAxisServoLineExtractor : IConstraintLineExtractor<LinearAxisServoPrestepData>
     {
-        public int LinesPerConstraint => 7;
+        public static int LinesPerConstraint => 7;
 
-        public unsafe void ExtractLines(ref LinearAxisServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref LinearAxisServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/OneBodyLinearServoLineExtractor.cs
+++ b/DemoRenderer/Constraints/OneBodyLinearServoLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct OneBodyLinearServoLineExtractor : IConstraintLineExtractor<OneBodyLinearServoPrestepData>
     {
-        public int LinesPerConstraint => 2;
+        public static int LinesPerConstraint => 2;
 
-        public unsafe void ExtractLines(ref OneBodyLinearServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref OneBodyLinearServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/PointOnLineLineExtractor.cs
+++ b/DemoRenderer/Constraints/PointOnLineLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct PointOnLineLineExtractor : IConstraintLineExtractor<PointOnLineServoPrestepData>
     {
-        public int LinesPerConstraint => 4;
+        public static int LinesPerConstraint => 4;
 
-        public unsafe void ExtractLines(ref PointOnLineServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref PointOnLineServoPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/SwivelHingeLineExtractor.cs
+++ b/DemoRenderer/Constraints/SwivelHingeLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct SwivelHingeLineExtractor : IConstraintLineExtractor<SwivelHingePrestepData>
     {
-        public int LinesPerConstraint => 5;
+        public static int LinesPerConstraint => 5;
 
-        public unsafe void ExtractLines(ref SwivelHingePrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref SwivelHingePrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/Constraints/WeldLineExtractor.cs
+++ b/DemoRenderer/Constraints/WeldLineExtractor.cs
@@ -8,9 +8,9 @@ namespace DemoRenderer.Constraints
 {
     struct WeldLineExtractor : IConstraintLineExtractor<WeldPrestepData>
     {
-        public int LinesPerConstraint => 2;
+        public static int LinesPerConstraint => 2;
 
-        public unsafe void ExtractLines(ref WeldPrestepData prestepBundle, int setIndex, int* bodyIndices,
+        public static unsafe void ExtractLines(ref WeldPrestepData prestepBundle, int setIndex, int* bodyIndices,
             Bodies bodies, ref Vector3 tint, ref QuickList<LineInstance> lines)
         {
             //Could do bundles of constraints at a time, but eh.

--- a/DemoRenderer/ShapeDrawing/ShapesExtractor.cs
+++ b/DemoRenderer/ShapeDrawing/ShapesExtractor.cs
@@ -280,7 +280,7 @@ namespace DemoRenderer.ShapeDrawing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void AddShape<TShape>(TShape shape, Shapes shapes, RigidPose pose, Vector3 color) where TShape : IShape
         {
-            AddShape(Unsafe.AsPointer(ref shape), shape.TypeId, shapes, pose, color, ref ShapeCache, pool);
+            AddShape(Unsafe.AsPointer(ref shape), TShape.TypeId, shapes, pose, color, ref ShapeCache, pool);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Demos/Demos/Characters/CharacterMotionConstraint.cs
+++ b/Demos/Demos/Characters/CharacterMotionConstraint.cs
@@ -62,16 +62,16 @@ namespace Demos.Demos.Characters
         /// <summary>
         /// Gets the constraint type id that this description is associated with. 
         /// </summary>
-        public readonly int ConstraintTypeId => StaticCharacterMotionTypeProcessor.BatchTypeId;
+        public static int ConstraintTypeId => StaticCharacterMotionTypeProcessor.BatchTypeId;
 
         /// <summary>
         /// Gets the TypeProcessor type that is associated with this description.
         /// </summary>
-        public readonly Type TypeProcessorType => typeof(StaticCharacterMotionTypeProcessor);    
+        public static Type TypeProcessorType => typeof(StaticCharacterMotionTypeProcessor);    
         /// <summary>
         /// Creates a type processor for this constraint type.
         /// </summary>
-        public readonly TypeProcessor CreateTypeProcessor() => new StaticCharacterMotionTypeProcessor();
+        public static TypeProcessor CreateTypeProcessor() => new StaticCharacterMotionTypeProcessor();
 
         //Note that these mapping functions use a "GetOffsetInstance" function. Each CharacterMotionPrestep is a bundle of multiple constraints;
         //by grabbing an offset instance, we're selecting a specific slot in the bundle to modify. For simplicity and to guarantee consistency of field strides,
@@ -88,7 +88,7 @@ namespace Demos.Demos.Characters
             Vector3Wide.WriteFirst(OffsetFromCharacterToSupportPoint, ref target.OffsetFromCharacter);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out StaticCharacterMotionConstraint description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out StaticCharacterMotionConstraint description)
         {
             ref var source = ref GetOffsetInstance(ref Buffer<StaticCharacterMotionPrestep>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
             QuaternionWide.ReadFirst(source.SurfaceBasis, out description.SurfaceBasis);
@@ -187,7 +187,7 @@ namespace Demos.Demos.Characters
         }
                
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref StaticCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, ref StaticCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA)
         {            
             ComputeJacobians(prestep.OffsetFromCharacter, prestep.SurfaceBasis,
                 out var basis, out var horizontalAngularJacobianA, out var verticalAngularJacobianA);
@@ -195,7 +195,7 @@ namespace Demos.Demos.Characters
             ApplyVerticalImpulse(basis, verticalAngularJacobianA, accumulatedImpulses.Vertical, inertiaA, ref velocityA);
         }
         
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref StaticCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, float dt, float inverseDt, ref StaticCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA)
         {            
             //The motion constraint is split into two parts: the horizontal constraint, and the vertical constraint.
             //The horizontal constraint acts almost exactly like the TangentFriction, but we'll duplicate some of the logic to keep this implementation self-contained.
@@ -263,8 +263,8 @@ namespace Demos.Demos.Characters
         }
 
         
-        public bool RequiresIncrementalSubstepUpdates => true;
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref StaticCharacterMotionPrestep prestep)
+        public static bool RequiresIncrementalSubstepUpdates => true;
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, ref StaticCharacterMotionPrestep prestep)
         {
             //Since collision detection doesn't run for every substep, we approximate the change in depth for the vertical motion constraint by integrating the velocity along the support normal.
             //This is pretty subtle. If you disable it entirely (return false from "RequiresIncrementalSubstepUpdates" above), you might not even notice.
@@ -335,16 +335,16 @@ namespace Demos.Demos.Characters
         /// <summary>
         /// Gets the constraint type id that this description is associated with. 
         /// </summary>
-        public readonly int ConstraintTypeId => DynamicCharacterMotionTypeProcessor.BatchTypeId;
+        public static int ConstraintTypeId => DynamicCharacterMotionTypeProcessor.BatchTypeId;
 
         /// <summary>
         /// Gets the TypeProcessor type that is associated with this description.
         /// </summary>
-        public readonly Type TypeProcessorType => typeof(DynamicCharacterMotionTypeProcessor);    
+        public static Type TypeProcessorType => typeof(DynamicCharacterMotionTypeProcessor);    
         /// <summary>
         /// Creates a type processor for this constraint type.
         /// </summary>
-        public readonly TypeProcessor CreateTypeProcessor() => new DynamicCharacterMotionTypeProcessor();
+        public static TypeProcessor CreateTypeProcessor() => new DynamicCharacterMotionTypeProcessor();
 
         //Note that these mapping functions use a "GetOffsetInstance" function. Each CharacterMotionPrestep is a bundle of multiple constraints;
         //by grabbing an offset instance, we're selecting a specific slot in the bundle to modify. For simplicity and to guarantee consistency of field strides,
@@ -362,7 +362,7 @@ namespace Demos.Demos.Characters
             Vector3Wide.WriteFirst(OffsetFromSupportToSupportPoint, ref target.OffsetFromSupport);
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out DynamicCharacterMotionConstraint description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out DynamicCharacterMotionConstraint description)
         {
             ref var source = ref GetOffsetInstance(ref Buffer<DynamicCharacterMotionPrestep>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
             QuaternionWide.ReadFirst(source.SurfaceBasis, out description.SurfaceBasis);
@@ -476,7 +476,7 @@ namespace Demos.Demos.Characters
         }
                
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref DynamicCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA, ref BodyVelocityWide velocityB)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, ref DynamicCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA, ref BodyVelocityWide velocityB)
         {            
             ComputeJacobians(prestep.OffsetFromCharacter, prestep.OffsetFromSupport, prestep.SurfaceBasis,
                 out var basis, out var horizontalAngularJacobianA, out var horizontalAngularJacobianB, out var verticalAngularJacobianA, out var verticalAngularJacobianB);
@@ -484,7 +484,7 @@ namespace Demos.Demos.Characters
             ApplyVerticalImpulse(basis, verticalAngularJacobianA, verticalAngularJacobianB, accumulatedImpulses.Vertical, inertiaA, inertiaB, ref velocityA, ref velocityB);
         }
         
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref DynamicCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA, ref BodyVelocityWide velocityB)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, float dt, float inverseDt, ref DynamicCharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA, ref BodyVelocityWide velocityB)
         {            
             //The motion constraint is split into two parts: the horizontal constraint, and the vertical constraint.
             //The horizontal constraint acts almost exactly like the TangentFriction, but we'll duplicate some of the logic to keep this implementation self-contained.
@@ -564,8 +564,8 @@ namespace Demos.Demos.Characters
         }
 
         
-        public bool RequiresIncrementalSubstepUpdates => true;
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref DynamicCharacterMotionPrestep prestep)
+        public static bool RequiresIncrementalSubstepUpdates => true;
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, in BodyVelocityWide velocityB, ref DynamicCharacterMotionPrestep prestep)
         {
             //Since collision detection doesn't run for every substep, we approximate the change in depth for the vertical motion constraint by integrating the velocity along the support normal.
             //This is pretty subtle. If you disable it entirely (return false from "RequiresIncrementalSubstepUpdates" above), you might not even notice.

--- a/Demos/Demos/Characters/CharacterMotionConstraint.tt
+++ b/Demos/Demos/Characters/CharacterMotionConstraint.tt
@@ -79,16 +79,16 @@ namespace Demos.Demos.Characters
         /// <summary>
         /// Gets the constraint type id that this description is associated with. 
         /// </summary>
-        public readonly int ConstraintTypeId => <#=prefix#>CharacterMotionTypeProcessor.BatchTypeId;
+        public static int ConstraintTypeId => <#=prefix#>CharacterMotionTypeProcessor.BatchTypeId;
 
         /// <summary>
         /// Gets the TypeProcessor type that is associated with this description.
         /// </summary>
-        public readonly Type TypeProcessorType => typeof(<#=prefix#>CharacterMotionTypeProcessor);    
+        public static Type TypeProcessorType => typeof(<#=prefix#>CharacterMotionTypeProcessor);    
         /// <summary>
         /// Creates a type processor for this constraint type.
         /// </summary>
-        public readonly TypeProcessor CreateTypeProcessor() => new <#=prefix#>CharacterMotionTypeProcessor();
+        public static TypeProcessor CreateTypeProcessor() => new <#=prefix#>CharacterMotionTypeProcessor();
 
         //Note that these mapping functions use a "GetOffsetInstance" function. Each CharacterMotionPrestep is a bundle of multiple constraints;
         //by grabbing an offset instance, we're selecting a specific slot in the bundle to modify. For simplicity and to guarantee consistency of field strides,
@@ -108,7 +108,7 @@ namespace Demos.Demos.Characters
 <#}#>
         }
 
-        public readonly void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out <#=prefix#>CharacterMotionConstraint description)
+        public static void BuildDescription(ref TypeBatch batch, int bundleIndex, int innerIndex, out <#=prefix#>CharacterMotionConstraint description)
         {
             ref var source = ref GetOffsetInstance(ref Buffer<<#=prefix#>CharacterMotionPrestep>.Get(ref batch.PrestepData, bundleIndex), innerIndex);
             QuaternionWide.ReadFirst(source.SurfaceBasis, out description.SurfaceBasis);
@@ -239,7 +239,7 @@ namespace Demos.Demos.Characters
         }
                
 
-        public void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(dynamic) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>ref <#=prefix#>CharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA<#if(dynamic) {#>, ref BodyVelocityWide velocityB<#}#>)
+        public static void WarmStart(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(dynamic) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>ref <#=prefix#>CharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA<#if(dynamic) {#>, ref BodyVelocityWide velocityB<#}#>)
         {            
             ComputeJacobians(prestep.OffsetFromCharacter, <#if (dynamic) {#>prestep.OffsetFromSupport, <#}#>prestep.SurfaceBasis,
                 out var basis, out var horizontalAngularJacobianA, <#if (dynamic) {#>out var horizontalAngularJacobianB, <#}#>out var verticalAngularJacobianA<#if (dynamic) {#>, out var verticalAngularJacobianB<#}#>);
@@ -247,7 +247,7 @@ namespace Demos.Demos.Characters
             ApplyVerticalImpulse(basis, verticalAngularJacobianA, <#if (dynamic) {#>verticalAngularJacobianB, <#}#>accumulatedImpulses.Vertical, inertiaA, <#if (dynamic) {#>inertiaB, <#}#>ref velocityA<#if (dynamic) {#>, ref velocityB<#}#>);
         }
         
-        public void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(dynamic) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>float dt, float inverseDt, ref <#=prefix#>CharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA<#if(dynamic) {#>, ref BodyVelocityWide velocityB<#}#>)
+        public static void Solve(in Vector3Wide positionA, in QuaternionWide orientationA, in BodyInertiaWide inertiaA, <#if(dynamic) {#>in Vector3Wide positionB, in QuaternionWide orientationB, in BodyInertiaWide inertiaB, <#}#>float dt, float inverseDt, ref <#=prefix#>CharacterMotionPrestep prestep, ref CharacterMotionAccumulatedImpulse accumulatedImpulses, ref BodyVelocityWide velocityA<#if(dynamic) {#>, ref BodyVelocityWide velocityB<#}#>)
         {            
             //The motion constraint is split into two parts: the horizontal constraint, and the vertical constraint.
             //The horizontal constraint acts almost exactly like the TangentFriction, but we'll duplicate some of the logic to keep this implementation self-contained.
@@ -339,8 +339,8 @@ namespace Demos.Demos.Characters
         }
 
         
-        public bool RequiresIncrementalSubstepUpdates => true;
-        public void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, <#if(dynamic){#>in BodyVelocityWide velocityB, <#}#>ref <#=prefix#>CharacterMotionPrestep prestep)
+        public static bool RequiresIncrementalSubstepUpdates => true;
+        public static void IncrementallyUpdateForSubstep(in Vector<float> dt, in BodyVelocityWide velocityA, <#if(dynamic){#>in BodyVelocityWide velocityB, <#}#>ref <#=prefix#>CharacterMotionPrestep prestep)
         {
             //Since collision detection doesn't run for every substep, we approximate the change in depth for the vertical motion constraint by integrating the velocity along the support normal.
             //This is pretty subtle. If you disable it entirely (return false from "RequiresIncrementalSubstepUpdates" above), you might not even notice.

--- a/Demos/Demos/ClothDemo.cs
+++ b/Demos/Demos/ClothDemo.cs
@@ -62,7 +62,7 @@ namespace Demos.Demos
             Material = material;
             MinimumDistanceForSelfCollisions = minimumDistanceForSelfCollisions;
         }
-        ClothCallbacks Dancers.IDancerNarrowPhaseCallbacks<ClothCallbacks, ClothCollisionFilter>.Create(CollidableProperty<ClothCollisionFilter> filters, PairMaterialProperties pairMaterialProperties, int minimumDistanceForSelfCollisions)
+        static ClothCallbacks Dancers.IDancerNarrowPhaseCallbacks<ClothCallbacks, ClothCollisionFilter>.Create(CollidableProperty<ClothCollisionFilter> filters, PairMaterialProperties pairMaterialProperties, int minimumDistanceForSelfCollisions)
         {
             return new ClothCallbacks(filters, pairMaterialProperties, minimumDistanceForSelfCollisions);
         }

--- a/Demos/Demos/CollisionQueryDemo.cs
+++ b/Demos/Demos/CollisionQueryDemo.cs
@@ -175,7 +175,7 @@ namespace Demos.Demos
             shape.ComputeBounds(pose.Orientation, out var boundingBoxMin, out var boundingBoxMax);
             boundingBoxMin += pose.Position;
             boundingBoxMax += pose.Position;
-            AddQueryToBatch(shape.TypeId, queryShapeData, queryShapeSize, boundingBoxMin, boundingBoxMax, pose, queryId, ref batcher);
+            AddQueryToBatch(TShape.TypeId, queryShapeData, queryShapeSize, boundingBoxMin, boundingBoxMax, pose, queryId, ref batcher);
         }
 
         //This version of the query isn't used in the demo, but shows how you could use a simulation-cached shape in a query.

--- a/Demos/Demos/CustomVoxelCollidableDemo.cs
+++ b/Demos/Demos/CustomVoxelCollidableDemo.cs
@@ -26,7 +26,7 @@ namespace Demos.Demos
     struct Voxels : IHomogeneousCompoundShape<Box, BoxWide>
     {
         //Type ids should be unique across all shape types in a simulation.
-        public readonly int TypeId => 12;
+        public static int TypeId => 12;
 
         //Using an object space tree isn't necessarily ideal for a highly regular data like voxels.
         //We're using it here since it exists already and a voxel-specialized version doesn't.
@@ -70,7 +70,7 @@ namespace Demos.Demos
             pool.Return(ref bounds);
         }
 
-        public readonly ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+        public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
         {
             //Shapes types are responsible for informing the shape system how to create a batch for them.
             //Convex shapes will return a ConvexShapeBatch<TShape>, compound shapes a CompoundShapeBatch<TShape>,

--- a/Demos/Demos/Dancers/DemoDancers.cs
+++ b/Demos/Demos/Dancers/DemoDancers.cs
@@ -74,7 +74,7 @@ namespace Demos.Demos.Dancers
     /// <typeparam name="TFilter">Type of the callback filters to use.</typeparam>
     public interface IDancerNarrowPhaseCallbacks<TCallbacks, TFilter> where TCallbacks : INarrowPhaseCallbacks, IDancerNarrowPhaseCallbacks<TCallbacks, TFilter> where TFilter : unmanaged
     {
-        TCallbacks Create(CollidableProperty<TFilter> filters, PairMaterialProperties pairMaterialProperties, int minimumDistanceForSelfCollisions);
+        static abstract TCallbacks Create(CollidableProperty<TFilter> filters, PairMaterialProperties pairMaterialProperties, int minimumDistanceForSelfCollisions);
     }
 
     /// <summary>
@@ -244,7 +244,7 @@ namespace Demos.Demos.Dancers
 
                 //If the required detail goes low enough, note that this demo disables cloth self collision to save some extra time.
                 //The ClothCallbacks specify a minimum distance required for self collision, and low detail (higher 'level of detail' values) results in MaxValue minimum distance.
-                var narrowPhaseCallbacks = default(TNarrowPhaseCallbacks).Create(dancerFilters, new PairMaterialProperties(0.4f, 20, new SpringSettings(120, 1)), levelOfDetail <= 0.5f ? 3 : int.MaxValue);
+                var narrowPhaseCallbacks = TNarrowPhaseCallbacks.Create(dancerFilters, new PairMaterialProperties(0.4f, 20, new SpringSettings(120, 1)), levelOfDetail <= 0.5f ? 3 : int.MaxValue);
                 var dancerSimulation = Simulation.Create(new BufferPool(16384), narrowPhaseCallbacks,
                     new DemoPoseIntegratorCallbacks(new Vector3(0, -10, 0)), dancerSolveDescription,
                     //To save some memory, initialize the dancer simulations with smaller starting sizes. For the higher level of detail simulations this could require some resizing. 

--- a/Demos/Demos/NewtDemo.cs
+++ b/Demos/Demos/NewtDemo.cs
@@ -552,7 +552,7 @@ namespace Demos.Demos
         {
         }
         //This slightly awkward factory is just here for the dancer demos.
-        DeformableCallbacks Dancers.IDancerNarrowPhaseCallbacks<DeformableCallbacks, DeformableCollisionFilter>.Create(CollidableProperty<DeformableCollisionFilter> filters, PairMaterialProperties pairMaterialProperties, int minimumDistanceForSelfCollisions)
+        static DeformableCallbacks Dancers.IDancerNarrowPhaseCallbacks<DeformableCallbacks, DeformableCollisionFilter>.Create(CollidableProperty<DeformableCollisionFilter> filters, PairMaterialProperties pairMaterialProperties, int minimumDistanceForSelfCollisions)
         {
             return new DeformableCallbacks(filters, pairMaterialProperties, minimumDistanceForSelfCollisions);
         }

--- a/Demos/Demos/SweepDemo.cs
+++ b/Demos/Demos/SweepDemo.cs
@@ -170,12 +170,12 @@ namespace Demos.Demos
         {
             var filter = new Filter();
 
-            var task = Simulation.NarrowPhase.SweepTaskRegistry.GetTask(a.TypeId, b.TypeId);
+            var task = Simulation.NarrowPhase.SweepTaskRegistry.GetTask(TShapeA.TypeId, TShapeB.TypeId);
             if (task == null)
                 return;
             var intersected = task.Sweep(
-                Unsafe.AsPointer(ref a), a.TypeId, poseA.Orientation, velocityA,
-                Unsafe.AsPointer(ref b), b.TypeId, poseB.Position - poseA.Position, poseB.Orientation, velocityB,
+                Unsafe.AsPointer(ref a), TShapeA.TypeId, poseA.Orientation, velocityA,
+                Unsafe.AsPointer(ref b), TShapeB.TypeId, poseB.Position - poseA.Position, poseB.Orientation, velocityB,
                 maximumT, 1e-2f, 1e-5f, 25, ref filter, Simulation.Shapes, Simulation.NarrowPhase.SweepTaskRegistry, BufferPool,
                 out var t0, out var t1, out var hitLocation, out var hitNormal);
             hitLocation += poseA.Position;

--- a/Demos/SpecializedTests/RayTesting.cs
+++ b/Demos/SpecializedTests/RayTesting.cs
@@ -8,20 +8,20 @@ namespace Demos.SpecializedTests
 {
     public interface IRayTester<T> where T : IShape
     {
-        void GetRandomShape(Random random, out T shape);
-        void GetPointInVolume(Random random, float innerMargin, ref T shape, out Vector3 localPointInCapsule);
-        void GetSurface(Random random, ref T shape, out Vector3 localPointOnCapsule, out Vector3 localNormal);
-        bool PointIsOnSurface(ref T shape, ref Vector3 localPoint);
+        static abstract void GetRandomShape(Random random, out T shape);
+        static abstract void GetPointInVolume(Random random, float innerMargin, ref T shape, out Vector3 localPointInCapsule);
+        static abstract void GetSurface(Random random, ref T shape, out Vector3 localPointOnCapsule, out Vector3 localNormal);
+        static abstract bool PointIsOnSurface(ref T shape, ref Vector3 localPoint);
     }
     public struct SphereRayTester : IRayTester<Sphere>
     {
-        public void GetRandomShape(Random random, out Sphere shape)
+        public static void GetRandomShape(Random random, out Sphere shape)
         {
             const float sizeMin = 0.1f;
             const float sizeSpan = 200;
             shape = new Sphere(sizeMin + sizeSpan * random.NextSingle());
         }
-        public void GetPointInVolume(Random random, float innerMargin, ref Sphere shape, out Vector3 localPoint)
+        public static void GetPointInVolume(Random random, float innerMargin, ref Sphere shape, out Vector3 localPoint)
         {
             float effectiveRadius = Math.Max(0, shape.Radius - innerMargin);
             float radiusSquared = effectiveRadius * effectiveRadius;
@@ -35,13 +35,13 @@ namespace Demos.SpecializedTests
             } while (localPoint.LengthSquared() > radiusSquared);
         }
 
-        public void GetSurface(Random random, ref Sphere sphere, out Vector3 localPoint, out Vector3 localNormal)
+        public static void GetSurface(Random random, ref Sphere sphere, out Vector3 localPoint, out Vector3 localNormal)
         {
             RayTesting.GetUnitDirection(random, out localNormal);
             localPoint = localNormal * sphere.Radius;
         }
 
-        public bool PointIsOnSurface(ref Sphere shape, ref Vector3 localPoint)
+        public static bool PointIsOnSurface(ref Sphere shape, ref Vector3 localPoint)
         {
             var surfaceDistance = localPoint.Length() - shape.Radius;
             if (surfaceDistance < 0)
@@ -52,13 +52,13 @@ namespace Demos.SpecializedTests
 
     public struct CapsuleRayTester : IRayTester<Capsule>
     {
-        public void GetRandomShape(Random random, out Capsule shape)
+        public static void GetRandomShape(Random random, out Capsule shape)
         {
             const float sizeMin = 0.1f;
             const float sizeSpan = 200;
             shape = new Capsule(sizeMin + sizeSpan * random.NextSingle(), sizeMin * sizeSpan * random.NextSingle());
         }
-        public void GetPointInVolume(Random random, float innerMargin, ref Capsule capsule, out Vector3 localPointInCapsule)
+        public static void GetPointInVolume(Random random, float innerMargin, ref Capsule capsule, out Vector3 localPointInCapsule)
         {
             float distanceSquared;
             float effectiveRadius = Math.Max(0, capsule.Radius - innerMargin);
@@ -75,7 +75,7 @@ namespace Demos.SpecializedTests
             } while (distanceSquared > radiusSquared);
         }
 
-        public void GetSurface(Random random, ref Capsule capsule, out Vector3 localPointOnCapsule, out Vector3 localNormal)
+        public static void GetSurface(Random random, ref Capsule capsule, out Vector3 localPointOnCapsule, out Vector3 localNormal)
         {
             float distanceSquared;
             float radiusSquared = capsule.Radius * capsule.Radius;
@@ -95,7 +95,7 @@ namespace Demos.SpecializedTests
             localPointOnCapsule = projectedCandidate + localNormal * capsule.Radius;
         }
 
-        public bool PointIsOnSurface(ref Capsule capsule, ref Vector3 localPoint)
+        public static bool PointIsOnSurface(ref Capsule capsule, ref Vector3 localPoint)
         {
             var projected = MathHelper.Clamp(localPoint.Y, -capsule.HalfLength, capsule.HalfLength);
             var surfaceDistance = Vector3.Distance(localPoint, new Vector3(0, projected, 0)) - capsule.Radius;
@@ -107,13 +107,13 @@ namespace Demos.SpecializedTests
 
     public struct CylinderRayTester : IRayTester<Cylinder>
     {
-        public void GetRandomShape(Random random, out Cylinder shape)
+        public static void GetRandomShape(Random random, out Cylinder shape)
         {
             const float sizeMin = 0.1f;
             const float sizeSpan = 200;
             shape = new Cylinder(sizeMin + sizeSpan * random.NextSingle(), sizeMin * sizeSpan * random.NextSingle());
         }
-        public void GetPointInVolume(Random random, float innerMargin, ref Cylinder cylinder, out Vector3 localPointInCylinder)
+        public static void GetPointInVolume(Random random, float innerMargin, ref Cylinder cylinder, out Vector3 localPointInCylinder)
         {
             float distanceSquared;
             float effectiveRadius = Math.Max(0, cylinder.Radius - innerMargin);
@@ -132,7 +132,7 @@ namespace Demos.SpecializedTests
             localPointInCylinder = new Vector3(randomHorizontal.X, -effectiveHalfLength + 2 * effectiveHalfLength * random.NextSingle(), randomHorizontal.Y);
         }
 
-        public void GetSurface(Random random, ref Cylinder cylinder, out Vector3 localPointOnCylinder, out Vector3 localNormal)
+        public static void GetSurface(Random random, ref Cylinder cylinder, out Vector3 localPointOnCylinder, out Vector3 localNormal)
         {
             float distanceSquared;
             var min = new Vector2(cylinder.Radius);
@@ -174,7 +174,7 @@ namespace Demos.SpecializedTests
             }
         }
 
-        public bool PointIsOnSurface(ref Cylinder cylinder, ref Vector3 localPoint)
+        public static bool PointIsOnSurface(ref Cylinder cylinder, ref Vector3 localPoint)
         {
             var epsilon = MathF.Max(cylinder.HalfLength, cylinder.Radius) * 1e-3f;
             if (MathF.Abs(localPoint.Y) > cylinder.HalfLength + epsilon)
@@ -202,13 +202,13 @@ namespace Demos.SpecializedTests
 
     public struct BoxRayTester : IRayTester<Box>
     {
-        public void GetRandomShape(Random random, out Box shape)
+        public static void GetRandomShape(Random random, out Box shape)
         {
             const float sizeMin = 0.1f;
             const float sizeSpan = 200;
             shape = new Box(sizeMin + sizeSpan * random.NextSingle(), sizeMin * sizeSpan * random.NextSingle(), sizeMin * sizeSpan * random.NextSingle());
         }
-        public void GetPointInVolume(Random random, float innerMargin, ref Box box, out Vector3 localPoint)
+        public static void GetPointInVolume(Random random, float innerMargin, ref Box box, out Vector3 localPoint)
         {
             var min = new Vector3(box.HalfWidth - innerMargin, box.HalfHeight - innerMargin, box.HalfLength - innerMargin);
             var span = min * 2;
@@ -216,7 +216,7 @@ namespace Demos.SpecializedTests
             localPoint = min + span * new Vector3(random.NextSingle(), random.NextSingle(), random.NextSingle());
         }
 
-        public void GetSurface(Random random, ref Box box, out Vector3 localPoint, out Vector3 localNormal)
+        public static void GetSurface(Random random, ref Box box, out Vector3 localPoint, out Vector3 localNormal)
         {
             var a = random.NextSingle();
             var b = random.NextSingle();
@@ -246,7 +246,7 @@ namespace Demos.SpecializedTests
             localPoint = (2 * a - 1) * x + (2 * b - 1) * y + z;
         }
 
-        public bool PointIsOnSurface(ref Box box, ref Vector3 localPoint)
+        public static bool PointIsOnSurface(ref Box box, ref Vector3 localPoint)
         {
             //Cast a ray against the box's bounding planes from the local origin using the local point as the direction.
             //In effect, all we're doing here is making sure that the closest plane impact has an offset similar to its box extent.
@@ -382,12 +382,11 @@ namespace Demos.SpecializedTests
 
             const float outwardPointingSpan = 1000f;
 
-            var tester = default(TTester);
             var random = new Random(5);
             TShapeWide shapeWide = default;
             for (int shapeIteration = 0; shapeIteration < shapeIterations; ++shapeIteration)
             {
-                tester.GetRandomShape(random, out var shape);
+                TTester.GetRandomShape(random, out var shape);
                 shapeWide.Broadcast(shape);
                 for (int transformIteration = 0; transformIteration < transformIterations; ++transformIteration)
                 {
@@ -400,9 +399,9 @@ namespace Demos.SpecializedTests
                     QuaternionWide.Broadcast(pose.Orientation, out poses.Orientation);
                     for (int rayIndex = 0; rayIndex < outsideToInsideRays; ++rayIndex)
                     {
-                        tester.GetSurface(random, ref shape, out var pointOnSurface, out var normal);
+                        TTester.GetSurface(random, ref shape, out var pointOnSurface, out var normal);
                         var localSourcePoint = pointOnSurface + normal * (outsideMinimumDistance + random.NextSingle() * outsideDistanceSpan);
-                        tester.GetPointInVolume(random, volumeInnerMargin, ref shape, out var localTargetPoint);
+                        TTester.GetPointInVolume(random, volumeInnerMargin, ref shape, out var localTargetPoint);
 
                         Matrix3x3.Transform(localSourcePoint, orientation, out var sourcePoint);
                         sourcePoint += pose.Position;
@@ -417,7 +416,7 @@ namespace Demos.SpecializedTests
                             var hitLocation = sourcePoint + t * direction;
                             var localHitLocation = hitLocation - pose.Position;
                             Matrix3x3.TransformTranspose(localHitLocation, orientation, out localHitLocation);
-                            if (!tester.PointIsOnSurface(ref shape, ref localHitLocation))
+                            if (!TTester.PointIsOnSurface(ref shape, ref localHitLocation))
                             {
                                 Console.WriteLine("Outside->inside ray detected non-surface impact.");
                             }
@@ -430,7 +429,7 @@ namespace Demos.SpecializedTests
                     }
                     for (int rayIndex = 0; rayIndex < insideRays; ++rayIndex)
                     {
-                        tester.GetPointInVolume(random, volumeInnerMargin, ref shape, out var localSourcePoint);
+                        TTester.GetPointInVolume(random, volumeInnerMargin, ref shape, out var localSourcePoint);
                         Matrix3x3.Transform(localSourcePoint, orientation, out var sourcePoint);
                         sourcePoint += pose.Position;
 
@@ -456,7 +455,7 @@ namespace Demos.SpecializedTests
                     for (int rayIndex = 0; rayIndex < outsideRays; ++rayIndex)
                     {
                         //Create a ray that lies on one of the shape's tangent planes, offset from the surface some amount to avoid numerical limitations.
-                        tester.GetSurface(random, ref shape, out var pointOnSurface, out var localNormal);
+                        TTester.GetSurface(random, ref shape, out var pointOnSurface, out var localNormal);
                         var localTargetPoint = pointOnSurface + localNormal * (tangentMinimumDistance + random.NextSingle() * tangentDistanceSpan);
                         var exclusion = tangentCentralExclusionMin + random.NextSingle() * tangentCentralExclusionSpan;
                         var span = 2 * exclusion + tangentSourceSpanMin + tangentSourceSpanSpan * random.NextSingle();
@@ -475,7 +474,7 @@ namespace Demos.SpecializedTests
                     }
                     for (int rayIndex = 0; rayIndex < outwardPointingRays; ++rayIndex)
                     {
-                        tester.GetSurface(random, ref shape, out var pointOnSurface, out var localNormal);
+                        TTester.GetSurface(random, ref shape, out var pointOnSurface, out var localNormal);
                         var localSourcePoint = pointOnSurface + localNormal * (tangentMinimumDistance + random.NextSingle() * tangentDistanceSpan);
                         Vector3 localTargetPoint;
                         do

--- a/Demos/SpecializedTests/TriangleTestDemo.cs
+++ b/Demos/SpecializedTests/TriangleTestDemo.cs
@@ -16,10 +16,9 @@ namespace Demos.SpecializedTests
 {
     public class TriangleTestDemo : Demo
     {
-        public unsafe override void Initialize(ContentArchive content, Camera camera)
+        public override void Initialize(ContentArchive content, Camera camera)
         {
             {
-                SphereTriangleTester tester;
                 SphereWide sphere = default;
                 sphere.Broadcast(new Sphere(0.5f));
                 TriangleWide triangle = default;
@@ -34,10 +33,9 @@ namespace Demos.SpecializedTests
                 var margin = new Vector<float>(1f);
                 Vector3Wide.Broadcast(new Vector3(1, -1, 0), out var offsetB);
                 QuaternionWide.Broadcast(QuaternionEx.CreateFromAxisAngle(new Vector3(0, 1, 0), MathF.PI / 2), out var orientationB);
-                tester.Test(ref sphere, ref triangle, ref margin, ref offsetB, ref orientationB, Vector<float>.Count, out var manifold);
+                SphereTriangleTester.Test(ref sphere, ref triangle, ref margin, ref offsetB, ref orientationB, Vector<float>.Count, out var manifold);
             }
             {
-                CapsuleTriangleTester tester;
                 CapsuleWide capsule = default;
                 capsule.Broadcast(new Capsule(0.5f, 0.5f));
                 TriangleWide triangle = default;
@@ -53,10 +51,9 @@ namespace Demos.SpecializedTests
                 Vector3Wide.Broadcast(new Vector3(-1f, -0.5f, -1f), out var offsetB);
                 QuaternionWide.Broadcast(QuaternionEx.CreateFromAxisAngle(Vector3.Normalize(new Vector3(-1, 0, 1)), MathHelper.PiOver2), out var orientationA);
                 QuaternionWide.Broadcast(QuaternionEx.CreateFromAxisAngle(new Vector3(0, 1, 0), 0), out var orientationB);
-                tester.Test(ref capsule, ref triangle, ref margin, ref offsetB, ref orientationA, ref orientationB, Vector<float>.Count, out var manifold);
+                CapsuleTriangleTester.Test(ref capsule, ref triangle, ref margin, ref offsetB, ref orientationA, ref orientationB, Vector<float>.Count, out var manifold);
             }
             {
-                BoxTriangleTester tester;
                 BoxWide shape = default;
                 shape.Broadcast(new Box(1f, 1f, 1f));
                 TriangleWide triangle = default;
@@ -72,10 +69,9 @@ namespace Demos.SpecializedTests
                 Vector3Wide.Broadcast(new Vector3(-1f, -0.5f, -1f), out var offsetB);
                 QuaternionWide.Broadcast(QuaternionEx.CreateFromAxisAngle(Vector3.Normalize(new Vector3(-1, 0, 1)), MathHelper.PiOver2), out var orientationA);
                 QuaternionWide.Broadcast(QuaternionEx.CreateFromAxisAngle(new Vector3(0, 1, 0), 0), out var orientationB);
-                tester.Test(ref shape, ref triangle, ref margin, ref offsetB, ref orientationA, ref orientationB, Vector<float>.Count, out var manifold);
+                BoxTriangleTester.Test(ref shape, ref triangle, ref margin, ref offsetB, ref orientationA, ref orientationB, Vector<float>.Count, out var manifold);
             }
             {
-                TrianglePairTester tester;
                 TriangleWide a = default, b = default;
                 a.Broadcast(new Triangle(new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(0, 0, 1)));
                 b.Broadcast(new Triangle(new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(0, 0, 1)));
@@ -84,7 +80,7 @@ namespace Demos.SpecializedTests
                 Vector3Wide.Broadcast(new Vector3(0, -1, 0), out var offsetB);
                 QuaternionWide.Broadcast(QuaternionEx.CreateFromAxisAngle(Vector3.Normalize(new Vector3(-1, 0, 1)), 0), out var orientationA);
                 QuaternionWide.Broadcast(QuaternionEx.CreateFromAxisAngle(new Vector3(0, 1, 0), 0), out var orientationB);
-                tester.Test(ref a, ref b, ref margin, ref offsetB, ref orientationA, ref orientationB, Vector<float>.Count, out var manifold);
+                TrianglePairTester.Test(ref a, ref b, ref margin, ref offsetB, ref orientationA, ref orientationB, Vector<float>.Count, out var manifold);
             }
             {
                 camera.Position = new Vector3(0, 3, -10);


### PR DESCRIPTION
Inspired by the TODO on `IShape`.

Primarily intended to eliminate the following two antipatterns:
- `default(T).Method()`
- `instance.Method(ref instance)`

This PR could be both overzealous (taking away the ability to vary behavior by instance) and non-exhaustive at the same time.
I addressed the above mentioned antipatterns, then skimmed over all interfaces and how they are used, trying to get a rough idea of whether making them static appears sensible. A deeper understanding of the engine might allow better judgement on some of these calls.

I've also taken the liberty of fixing a typo here and there and removing a redundant `unsafe` when it was next to the code I was modifying.

I understand that this PR is quite large (although it contains no functional changes!) If desired I could split it up into a part solely addressing the "safe" fixes to the antipatterns above and then see where it's going from there.

P.S.: Thank you for this awesome lib!