### PR TITLE
Introduce `IDisposableShape`

### DIFF
--- a/BepuPhysics/Collidables/ConvexHull.cs
+++ b/BepuPhysics/Collidables/ConvexHull.cs
@@ -33,7 +33,7 @@ namespace BepuPhysics.Collidables
         }
     }
 
-    public struct ConvexHull : IConvexShape
+    public struct ConvexHull : IConvexShape, IDisposableShape
     {
         /// <summary>
         /// Bundled points of the convex hull.

--- a/BepuPhysics/Collidables/IDisposableShape.cs
+++ b/BepuPhysics/Collidables/IDisposableShape.cs
@@ -1,0 +1,13 @@
+﻿using BepuUtilities.Memory;
+
+namespace BepuPhysics.Collidables
+{
+	public interface IDisposableShape : IShape
+	{
+		/// <summary>
+		/// Returns all resources used by the shape instance to the given pool.
+		/// </summary>
+		/// <param name="pool">Pool to return shape resources to.</param>
+		void Dispose(BufferPool pool);
+	}
+}

--- a/BepuPhysics/Collidables/IShape.cs
+++ b/BepuPhysics/Collidables/IShape.cs
@@ -82,7 +82,7 @@ namespace BepuPhysics.Collidables
     /// <summary>
     /// Defines a compound shape type that has children of potentially different types.
     /// </summary>
-    public interface ICompoundShape : IShape, IBoundsQueryableCompound
+    public interface ICompoundShape : IDisposableShape, IBoundsQueryableCompound
     {
         //Note that compound shapes have no wide GetBounds function. Compounds, by virtue of containing shapes of different types, cannot be usefully vectorized over.
         //Instead, their children are added to other computation batches.
@@ -135,11 +135,6 @@ namespace BepuPhysics.Collidables
         /// <param name="compoundChildIndex">Index of the child to look up.</param>
         /// <returns>Reference to the requested compound child.</returns>
         ref CompoundChild GetChild(int compoundChildIndex);
-        /// <summary>
-        /// Returns all resources used by the shape instance to the given pool.
-        /// </summary>
-        /// <param name="pool">Pool to return shape resources to.</param>
-        void Dispose(BufferPool pool);
     }
 
     /// <summary>
@@ -147,7 +142,7 @@ namespace BepuPhysics.Collidables
     /// </summary>
     /// <typeparam name="TChildShape">Type of the child shapes.</typeparam>
     /// <typeparam name="TChildShapeWide">Type of the child shapes, formatted in AOSOA layout.</typeparam>
-    public interface IHomogeneousCompoundShape<TChildShape, TChildShapeWide> : IShape, IBoundsQueryableCompound
+    public interface IHomogeneousCompoundShape<TChildShape, TChildShapeWide> : IDisposableShape, IBoundsQueryableCompound
         where TChildShape : unmanaged, IConvexShape
         where TChildShapeWide : unmanaged, IShapeWide<TChildShape>
     {
@@ -199,11 +194,6 @@ namespace BepuPhysics.Collidables
         /// <param name="childIndex">Index of the child in the compound parent.</param>
         /// <param name="childData">Reference to an AOSOA slot.</param>
         void GetLocalChild(int childIndex, ref TChildShapeWide childData);
-        /// <summary>
-        /// Returns all resources used by the shape instance to the given pool.
-        /// </summary>
-        /// <param name="pool">Pool to return shape resources to.</param>
-        void Dispose(BufferPool pool);
     }
 
     /// <summary>


### PR DESCRIPTION
Allows for properly disposing of a shape, given only an `IShape` without having to do various type checks.

An alternative approach would be introducing something like `IBufferPoolDisposable` and tagging everything in the library that supports disposing via a buffer pool. Potential use cases for that would be tracking everything that needs disposing for a `BufferPool` instance or something along those lines? If that seems like a more appropriate approach I can adjust the PR, but I personally feel like this is probably sufficient for now.