### PR TITLE
Update GL projects to .NET 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ ModelManifest.xml
 
 # Don't ignore content files that happen to use the .obj extension.
 !Demos/Content/*.obj
+
+# JetBrains Rider
+.idea/

--- a/DemoRenderer.GL/DemoRenderer.csproj
+++ b/DemoRenderer.GL/DemoRenderer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Demos.GL/Demos.csproj
+++ b/Demos.GL/Demos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/Demos/Demos/Characters/CharacterControllers.cs
+++ b/Demos/Demos/Characters/CharacterControllers.cs
@@ -85,7 +85,7 @@ namespace Demos.Demos.Characters
     public unsafe class CharacterControllers : IDisposable
     {
         /// <summary>
-        /// Gets the simulation to which this set of chracters belongs.
+        /// Gets the simulation to which this set of characters belongs.
         /// </summary>
         public Simulation Simulation { get; private set; }
         BufferPool pool;
@@ -99,7 +99,7 @@ namespace Demos.Demos.Characters
         public int CharacterCount { get { return characters.Count; } }
 
         /// <summary>
-        /// Creates a character controller systme.
+        /// Creates a character controller system.
         /// </summary>
         /// <param name="pool">Pool to allocate resources from.</param>
         /// <param name="initialCharacterCapacity">Number of characters to initially allocate space for.</param>

--- a/Demos/Demos/Characters/CharacterDemo.cs
+++ b/Demos/Demos/Characters/CharacterDemo.cs
@@ -135,10 +135,10 @@ namespace Demos.Demos.Characters
                 pose.Orientation = Quaternion.Identity;
                 return pose;
             };
-            var platormShapeIndex = Simulation.Shapes.Add(new Box(5, 1, 5));
+            var platformShapeIndex = Simulation.Shapes.Add(new Box(5, 1, 5));
             for (int i = 0; i < movingPlatforms.Length; ++i)
             {
-                movingPlatforms[i] = new MovingPlatform(platormShapeIndex, i * 3559, 1f / 60f, Simulation, poseCreator);
+                movingPlatforms[i] = new MovingPlatform(platformShapeIndex, i * 3559, 1f / 60f, Simulation, poseCreator);
             }
             var box = new Box(4, 1, 4);
             var boxShapeIndex = Simulation.Shapes.Add(box);


### PR DESCRIPTION
Fixes not being able to build and run Demos.GL project:

```
Project BepuPhysics is not compatible with net7.0 (.NETCoreApp,Version=v7.0). Project BepuPhysics supports: net8.0 (.NETCoreApp,Version=v8.0)
```

These 2 projects seem to have been missed in this commit: https://github.com/bepu/bepuphysics2/commit/13b9ff35ac3939856fd09a2f821157d188c6d2bc