### PR TITLE
GL: Use compile/link status for errors

### DIFF
--- a/DemoRenderer.GL/Shader.cs
+++ b/DemoRenderer.GL/Shader.cs
@@ -15,8 +15,12 @@ namespace DemoRenderer
             {
                 GL.ShaderSource(handle, source);
                 GL.CompileShader(handle);
-                var error = GL.GetShaderInfoLog(handle);
-                if (error != string.Empty) throw new Exception(error);
+                GL.GetShader(handle, ShaderParameter.CompileStatus, out var compileStatus);
+                if(compileStatus == 0)
+                {
+                    var error = GL.GetShaderInfoLog(handle);
+                    throw new Exception(error);
+                }
                 GL.AttachShader(program, handle);
                 try
                 {
@@ -38,8 +42,12 @@ namespace DemoRenderer
             Compile(ShaderType.FragmentShader, fragment, () =>
             {
                 GL.LinkProgram(program);
-                var error = GL.GetProgramInfoLog(program);
-                if (error != string.Empty) throw new Exception(error);
+                GL.GetProgram(program, GetProgramParameterName.LinkStatus, out var linkStatus);
+                if(linkStatus == 0)
+                {
+                    var error = GL.GetProgramInfoLog(program);
+                    throw new Exception(error);
+                }
             }));
         public void Use()
         {


### PR DESCRIPTION
Fixes demo crashing when the shader compiler reports warnings in the info log.

Example of previous error on Linux:

```
Unhandled exception. System.Exception: 0:49(38): warning: `_189' used uninitialized
0:49(51): warning: `_192' used uninitialized
0:49(64): warning: `_194' used uninitialized
```