### PR TITLE
ci: Add release.yml for changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking-change
+    - title: 🎉 New Features
+      labels:
+        - enhancement
+        - new-feature
+    - title: 🚀 Performance
+      labels:
+        - performance
+    - title: 🧠 Fiddling
+      labels:
+        - fiddling
+    - title: 🎮 Demos App
+      labels:
+        - demos
+    - title: 📄 Documentation
+      labels:
+        - documentation
+    - title: 💪 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This PR is just a preparation for auto generation of release notes. Once merged, it isn't going to do anything yet, till the GitHub Action is updated. I will make a follow up PR(s).

Feel free to rename titles and labels as desired.

**Important notes:**

- exclude section excludes certain PRs in the release notes, for example from dependabot
- you need to create the labels so the release notes will be catogorised accordingly:
  - ignore-for-release
  - breaking-change
  - new-feature
  - performance
  - fiddling
  - demos
  - documentation
- you **must** label each PR, which you would like to categorised, otherwise it will appear in the Other Changes section.
- ideally, if the conditions allow, the PRs should be split according these labels 🤣

Other notes:

- Added a new `release.yml` file to the `.github` directory.
- Configures the changelog generation for releases.
- Specifies labels to exclude from the changelog, such as `ignore-for-release` and contributions from `dependabot`.
- Categorizes the changelog into several sections