### PR TITLE
ci: GitHub Actions update

### DIFF
--- a/.github/workflows/dotnet-core-publish.yml
+++ b/.github/workflows/dotnet-core-publish.yml
@@ -1,0 +1,56 @@
+name: .NET Core - Publish NuGet Packages
+
+env:
+  COMMON_SETTINGS_PATH: CommonSettings.props
+  BASE_RUN_NUMBER: 25
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Print run_number
+      run: echo ${{ github.run_number }}
+    - name: Set version number
+      run: |
+        $version = "2.5.0-beta.$(${{ github.run_number }} + $env:BASE_RUN_NUMBER)"
+        echo "VERSION=$version" >> $env:GITHUB_ENV
+      shell: powershell
+    - name: Print VERSION
+      run: echo "VERSION is $env:VERSION"
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.x'
+        include-prerelease: true
+    - name: Set Version in CommonSettings.props
+      run: |
+        $settingsContent = Get-Content -Path ${{ env.COMMON_SETTINGS_PATH }} -Raw
+        $updatedContent = $settingsContent -replace '<Version>.*?</Version>', "<Version>${{ env.VERSION }}</Version>"
+        Set-Content -Path ${{ env.COMMON_SETTINGS_PATH }} -Value $updatedContent
+    - name: Install dependencies
+      run: |
+        dotnet restore DemoContentBuilder
+        dotnet restore Demos
+    - name: Build
+      run: |
+        dotnet build DemoContentBuilder --configuration Release --no-restore /p:Platform=x64
+        dotnet build Demos --configuration Release --no-restore
+    - name: Test
+      run: dotnet test DemoTests -c Release --verbosity normal
+    - name: Publish
+      if: github.event_name != 'pull_request'
+      run: |
+        dotnet nuget add source "https://nuget.pkg.github.com/bepu/index.json" --name "github" --username "rossnordby" --password "${{secrets.GITHUB_TOKEN}}"
+        dotnet pack "BepuPhysics" -c Release
+        dotnet pack "BepuUtilities" -c Release
+        dotnet nuget push "**/*.nupkg" -s "github" -k "${{secrets.GITHUB_TOKEN}}" --skip-duplicate
+        dotnet nuget push "**/*.nupkg" -s "https://api.nuget.org/v3/index.json" -k "${{secrets.NUGET_KEY}}" --skip-duplicate
+    - name: Create GitHub Release Draft
+      run: |
+        gh release create ${{ env.VERSION }} --title "v${{ env.VERSION }}" --notes "Release notes for ${{ env.VERSION }}" --draft
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,6 +1,14 @@
 name: .NET Core - Build and Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.github/**'
+      - 'Documentation/**'  
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'Documentation/**'
 
 jobs:
   build:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET Core - Build and Test
 
 on: [push, pull_request]
 
@@ -8,8 +8,8 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2 
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '9.x'
         include-prerelease: true
@@ -23,11 +23,11 @@ jobs:
         dotnet build Demos --configuration Release --no-restore
     - name: Test
       run: dotnet test DemoTests -c Release --verbosity normal
-    - name: Publish
-      if: github.event_name != 'pull_request'
-      run: |
-        dotnet nuget add source "https://nuget.pkg.github.com/bepu/index.json" --name "github" --username "rossnordby" --password "${{secrets.GITHUB_TOKEN}}"
-        dotnet pack "BepuPhysics" -c Release
-        dotnet pack "BepuUtilities" -c Release
-        dotnet nuget push "**/*.nupkg" -s "github" -k "${{secrets.GITHUB_TOKEN}}" --skip-duplicate
-        dotnet nuget push "**/*.nupkg" -s "https://api.nuget.org/v3/index.json" -k "${{secrets.NUGET_KEY}}" --skip-duplicate
+#    - name: Publish
+#      if: github.event_name != 'pull_request'
+#      run: |
+#        dotnet nuget add source "https://nuget.pkg.github.com/bepu/index.json" --name "github" --username "rossnordby" --password "${{secrets.GITHUB_TOKEN}}"
+#        dotnet pack "BepuPhysics" -c Release
+#        dotnet pack "BepuUtilities" -c Release
+#        dotnet nuget push "**/*.nupkg" -s "github" -k "${{secrets.GITHUB_TOKEN}}" --skip-duplicate
+#        dotnet nuget push "**/*.nupkg" -s "https://api.nuget.org/v3/index.json" -k "${{secrets.NUGET_KEY}}" --skip-duplicate


### PR DESCRIPTION
This is the final PR, which will create a tag and draft release. The main aim of these changes is to make it easier to see what PRs were made each release.

- updated: dotnet-core.yml
  - Disabling NuGet Publish
  - Add ignore paths, no need to trigger GitHub Actions when certain folders are updated
  - Actions version bumped
  - Name renamed
- new: dotnet-core-publish.yml
  - the same functionality as dotnet-core.yml
  - manual NuGet Publish by running this action
  - version auto increment
  - draft release creation, which should help bringing PRs summaries as you can see in the image below
  - once the draft release is published, everyone with notification set should be notified about the release by email automatically

![image](https://github.com/user-attachments/assets/21d20935-be30-4e41-bfe1-60994fdfaa13)
