### PR TITLE
No more stack overrun on pathological tree queries!

### DIFF
--- a/BepuPhysics/Collidables/IShape.cs
+++ b/BepuPhysics/Collidables/IShape.cs
@@ -104,9 +104,6 @@ namespace BepuPhysics.Collidables
         /// <param name="bodyIndex">Index of the body in the active body set; used to accumulate child bounds results.</param>
         void AddChildBoundsToBatcher(ref BoundingBoxBatcher batcher, in RigidPose pose, in BodyVelocity velocity, int bodyIndex);
 
-        //Compound shapes may require indirections into other shape batches. This isn't wonderfully fast, but this scalar path is designed more for convenience than performance anyway.
-        //For performance, a batched and vectorized codepath should be used.
-
         /// <summary>
         /// Tests a ray against the shape.
         /// </summary>
@@ -114,8 +111,9 @@ namespace BepuPhysics.Collidables
         /// <param name="ray">Ray to test against the shape.</param>
         /// <param name="maximumT">Maximum distance along the ray, in units of the ray direction's length, that the ray will test.</param>
         /// <param name="shapeBatches">Shape batches to look up child shapes in if necessary.</param>
+        /// <param name="pool">Buffer pool used for any temporary allocations required by the test.</param>
         /// <param name="hitHandler">Callbacks called when the ray interacts with a test candidate.</param>
-        void RayTest<TRayHitHandler>(in RigidPose pose, in RayData ray, ref float maximumT, Shapes shapeBatches, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
+        void RayTest<TRayHitHandler>(in RigidPose pose, in RayData ray, ref float maximumT, Shapes shapeBatches, BufferPool pool, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
 
         /// <summary>
         /// Tests multiple rays against the shape.
@@ -124,7 +122,8 @@ namespace BepuPhysics.Collidables
         /// <param name="rays">Rays to test against the shape.</param>
         /// <param name="shapeBatches">Shape batches to look up child shapes in if necessary.</param>
         /// <param name="hitHandler">Callbacks called when the ray interacts with a test candidate.</param>
-        void RayTest<TRayHitHandler>(in RigidPose pose, ref RaySource rays, Shapes shapeBatches, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
+        /// <param name="pool">Buffer pool used for any temporary allocations required by the test.</param>
+        void RayTest<TRayHitHandler>(in RigidPose pose, ref RaySource rays, Shapes shapeBatches, BufferPool pool, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
         /// <summary>
         /// Gets the number of children in the compound shape.
         /// </summary>
@@ -160,16 +159,18 @@ namespace BepuPhysics.Collidables
         /// <param name="pose">Pose of the shape during the ray test.</param>
         /// <param name="ray">Ray to test against the shape.</param>
         /// <param name="maximumT">Maximum distance along the ray, in units of the ray direction's length, that the ray will test.</param>
+        /// <param name="pool">Buffer pool used for any temporary allocations required by the test.</param>
         /// <param name="hitHandler">Callbacks called when the ray interacts with a test candidate.</param>
-        void RayTest<TRayHitHandler>(in RigidPose pose, in RayData ray, ref float maximumT, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
+        void RayTest<TRayHitHandler>(in RigidPose pose, in RayData ray, ref float maximumT, BufferPool pool, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
 
         /// <summary>
         /// Tests multiple rays against the shape.
         /// </summary>
         /// <param name="pose">Pose of the shape during the ray test.</param>
         /// <param name="rays">Rays to test against the shape.</param>
+        /// <param name="pool">Buffer pool used for any temporary allocations required by the test.</param>
         /// <param name="hitHandler">Callbacks called when the ray interacts with a test candidate.</param>
-        void RayTest<TRayHitHandler>(in RigidPose pose, ref RaySource rays, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
+        void RayTest<TRayHitHandler>(in RigidPose pose, ref RaySource rays, BufferPool pool, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
         /// <summary>
         /// Gets the number of children in the compound shape.
         /// </summary>

--- a/BepuPhysics/Collidables/Shapes.cs
+++ b/BepuPhysics/Collidables/Shapes.cs
@@ -72,8 +72,27 @@ namespace BepuPhysics.Collidables
         {
             throw new InvalidOperationException("Nonconvex shapes are not required to have a maximum radius or angular expansion implementation. This should only ever be called on convexes.");
         }
-        public abstract void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
-        public abstract void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, ref RaySource rays, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
+        /// <summary>
+        /// Tests a ray against a shape in the batch.
+        /// </summary>
+        /// <typeparam name="TRayHitHandler">Type of the hit handler that will have results reported to it.</typeparam>
+        /// <param name="shapeIndex">Index of the shape in the batch to test.</param>
+        /// <param name="pose">Pose of the shape to use for the test.</param>
+        /// <param name="ray">Ray to test against the shape.</param>
+        /// <param name="maximumT">The maximum parametric distance along the line. May be mutated by the hit handler.</param>
+        /// <param name="hitHandler">Hit handler that will process the reported hits.</param>
+        /// <param name="pool">Pool used for temporary allocations required by the test, if any.</param>
+        public abstract void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, BufferPool pool, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
+        /// <summary>
+        /// Tests a bunch of rays against a shape in the batch.
+        /// </summary>
+        /// <typeparam name="TRayHitHandler">Type of the hit handler that will have results reported to it.</typeparam>
+        /// <param name="shapeIndex">Index of the shape in the batch to test.</param>
+        /// <param name="pose">Pose of the shape to use for the test.</param>
+        /// <param name="rays">Rays to test against the shape.</param>
+        /// <param name="hitHandler">Hit handler that will process the reported hits.</param>
+        /// <param name="pool">Pool used for temporary allocations required by the test, if any.</param>
+        public abstract void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, ref RaySource rays, BufferPool pool, ref TRayHitHandler hitHandler) where TRayHitHandler : struct, IShapeRayHitHandler;
 
         /// <summary>
         /// Gets a raw untyped pointer to a shape's data.
@@ -266,7 +285,7 @@ namespace BepuPhysics.Collidables
             shape.ComputeAngularExpansionData(out maximumRadius, out angularExpansion);
         }
 
-        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, ref TRayHitHandler hitHandler)
+        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, BufferPool pool, ref TRayHitHandler hitHandler)
         {
             if (shapes[shapeIndex].RayTest(pose, ray.Origin, ray.Direction, out var t, out var normal) && t <= maximumT)
             {
@@ -274,7 +293,7 @@ namespace BepuPhysics.Collidables
             }
         }
 
-        public override void RayTest<TRayHitHandler>(int index, in RigidPose pose, ref RaySource rays, ref TRayHitHandler hitHandler)
+        public override void RayTest<TRayHitHandler>(int index, in RigidPose pose, ref RaySource rays, BufferPool pool, ref TRayHitHandler hitHandler)
         {
             WideRayTester.Test<RaySource, TShape, TShapeWide, TRayHitHandler>(ref shapes[index], pose, ref rays, ref hitHandler);
         }
@@ -321,14 +340,14 @@ namespace BepuPhysics.Collidables
         {
             shapes[shapeIndex].ComputeBounds(orientation, out min, out max);
         }
-        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, ref TRayHitHandler hitHandler)
+        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, BufferPool pool, ref TRayHitHandler hitHandler)
         {
-            shapes[shapeIndex].RayTest(pose, ray, ref maximumT, ref hitHandler);
+            shapes[shapeIndex].RayTest(pose, ray, ref maximumT, pool, ref hitHandler);
         }
 
-        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, ref RaySource rays, ref TRayHitHandler hitHandler)
+        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, ref RaySource rays, BufferPool pool, ref TRayHitHandler hitHandler)
         {
-            shapes[shapeIndex].RayTest(pose, ref rays, ref hitHandler);
+            shapes[shapeIndex].RayTest(pose, ref rays, pool, ref hitHandler);
         }
     }
 
@@ -367,14 +386,14 @@ namespace BepuPhysics.Collidables
             shapes[shapeIndex].ComputeBounds(orientation, shapeBatches, out min, out max);
         }
 
-        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, ref TRayHitHandler hitHandler)
+        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, in RayData ray, ref float maximumT, BufferPool pool, ref TRayHitHandler hitHandler)
         {
-            shapes[shapeIndex].RayTest(pose, ray, ref maximumT, shapeBatches, ref hitHandler);
+            shapes[shapeIndex].RayTest(pose, ray, ref maximumT, shapeBatches, pool, ref hitHandler);
         }
 
-        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, ref RaySource rays, ref TRayHitHandler hitHandler)
+        public override void RayTest<TRayHitHandler>(int shapeIndex, in RigidPose pose, ref RaySource rays, BufferPool pool, ref TRayHitHandler hitHandler)
         {
-            shapes[shapeIndex].RayTest(pose, ref rays, shapeBatches, ref hitHandler);
+            shapes[shapeIndex].RayTest(pose, ref rays, shapeBatches, pool, ref hitHandler);
         }
     }
 

--- a/BepuPhysics/CollisionDetection/BroadPhase_Queries.cs
+++ b/BepuPhysics/CollisionDetection/BroadPhase_Queries.cs
@@ -23,9 +23,9 @@ namespace BepuPhysics.CollisionDetection
             public Buffer<CollidableReference> Leaves;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void TestLeaf(int leafIndex, RayData* rayData, float* maximumT)
+            public unsafe void TestLeaf(int leafIndex, RayData* rayData, float* maximumT, BufferPool pool)
             {
-                LeafTester.RayTest(Leaves[leafIndex], rayData, maximumT);
+                LeafTester.RayTest(Leaves[leafIndex], rayData, maximumT, pool);
             }
         }
 
@@ -36,17 +36,18 @@ namespace BepuPhysics.CollisionDetection
         /// <param name="origin">Origin of the ray to cast.</param>
         /// <param name="direction">Direction of the ray to cast.</param>
         /// <param name="maximumT">Maximum length of the ray traversal in units of the direction's length.</param>
+        /// <param name="pool">The buffer pool used for any temporary allocations required during the traversal.</param>
         /// <param name="rayTester">Callback to execute on ray-leaf bounding box intersections.</param>
         /// <param name="id">User specified id of the ray.</param>
-        public unsafe void RayCast<TRayTester>(Vector3 origin, Vector3 direction, float maximumT, ref TRayTester rayTester, int id = 0) where TRayTester : IBroadPhaseRayTester
+        public unsafe void RayCast<TRayTester>(Vector3 origin, Vector3 direction, float maximumT, BufferPool pool, ref TRayTester rayTester, int id = 0) where TRayTester : IBroadPhaseRayTester
         {
             TreeRay.CreateFrom(origin, direction, maximumT, id, out var rayData, out var treeRay);
             RayLeafTester<TRayTester> tester;
             tester.LeafTester = rayTester;
             tester.Leaves = ActiveLeaves;
-            ActiveTree.RayCast(&treeRay, &rayData, ref tester);
+            ActiveTree.RayCast(&treeRay, &rayData, pool, ref tester);
             tester.Leaves = StaticLeaves;
-            StaticTree.RayCast(&treeRay, &rayData, ref tester);
+            StaticTree.RayCast(&treeRay, &rayData, pool, ref tester);
             //The sweep tester probably relies on mutation to function; copy any mutations back to the original reference.
             rayTester = tester.LeafTester;
         }
@@ -72,17 +73,18 @@ namespace BepuPhysics.CollisionDetection
         /// <param name="max">Maximum bounds of the box to sweep.</param>
         /// <param name="direction">Direction along which to sweep the bounding box.</param>
         /// <param name="maximumT">Maximum length of the sweep in units of the direction's length.</param>
+        /// <param name="pool">Pool to use for temporary allocations required by the traversal, if any.</param>
         /// <param name="sweepTester">Callback to execute on sweep-leaf bounding box intersections.</param>
-        public unsafe void Sweep<TSweepTester>(Vector3 min, Vector3 max, Vector3 direction, float maximumT, ref TSweepTester sweepTester) where TSweepTester : IBroadPhaseSweepTester
+        public unsafe void Sweep<TSweepTester>(Vector3 min, Vector3 max, Vector3 direction, float maximumT, BufferPool pool, ref TSweepTester sweepTester) where TSweepTester : IBroadPhaseSweepTester
         {
             Tree.ConvertBoxToCentroidWithExtent(min, max, out var origin, out var expansion);
             TreeRay.CreateFrom(origin, direction, maximumT, out var treeRay);
             SweepLeafTester<TSweepTester> tester;
             tester.LeafTester = sweepTester;
             tester.Leaves = ActiveLeaves;
-            ActiveTree.Sweep(expansion, origin, direction, &treeRay, ref tester);
+            ActiveTree.Sweep(expansion, origin, direction, &treeRay, pool, ref tester);
             tester.Leaves = StaticLeaves;
-            StaticTree.Sweep(expansion, origin, direction, &treeRay, ref tester);
+            StaticTree.Sweep(expansion, origin, direction, &treeRay, pool, ref tester);
             //The sweep tester probably relies on mutation to function; copy any mutations back to the original reference.
             sweepTester = tester.LeafTester;
         }
@@ -94,10 +96,11 @@ namespace BepuPhysics.CollisionDetection
         /// <param name="boundingBox">Bounding box to sweep.</param>
         /// <param name="direction">Direction along which to sweep the bounding box.</param>
         /// <param name="maximumT">Maximum length of the sweep in units of the direction's length.</param>
+        /// <param name="pool">Pool used for temporary allocations required by the test, if any.</param>
         /// <param name="sweepTester">Callback to execute on sweep-leaf bounding box intersections.</param>
-        public void Sweep<TSweepTester>(in BoundingBox boundingBox, Vector3 direction, float maximumT, ref TSweepTester sweepTester) where TSweepTester : IBroadPhaseSweepTester
+        public void Sweep<TSweepTester>(in BoundingBox boundingBox, Vector3 direction, float maximumT, BufferPool pool, ref TSweepTester sweepTester) where TSweepTester : IBroadPhaseSweepTester
         {
-            Sweep(boundingBox.Min, boundingBox.Max, direction, maximumT, ref sweepTester);
+            Sweep(boundingBox.Min, boundingBox.Max, direction, maximumT, pool, ref sweepTester);
         }
 
         struct BoxQueryEnumerator<TInnerEnumerator> : IBreakableForEach<int> where TInnerEnumerator : IBreakableForEach<CollidableReference>
@@ -118,15 +121,16 @@ namespace BepuPhysics.CollisionDetection
         /// <typeparam name="TOverlapEnumerator">Type of the enumerator to call for overlaps.</typeparam>
         /// <param name="min">Minimum bounds of the query box.</param>
         /// <param name="max">Maximum bounds of the query box.</param>
+        /// <param name="pool">Pool used for temporary allocations required by the test, if any.</param>
         /// <param name="overlapEnumerator">Enumerator to call for overlaps.</param>
-        public void GetOverlaps<TOverlapEnumerator>(Vector3 min, Vector3 max, ref TOverlapEnumerator overlapEnumerator) where TOverlapEnumerator : IBreakableForEach<CollidableReference>
+        public void GetOverlaps<TOverlapEnumerator>(Vector3 min, Vector3 max, BufferPool pool, ref TOverlapEnumerator overlapEnumerator) where TOverlapEnumerator : IBreakableForEach<CollidableReference>
         {
             BoxQueryEnumerator<TOverlapEnumerator> enumerator;
             enumerator.Enumerator = overlapEnumerator;
             enumerator.Leaves = ActiveLeaves;
-            ActiveTree.GetOverlaps(min, max, ref enumerator);
+            ActiveTree.GetOverlaps(min, max, pool, ref enumerator);
             enumerator.Leaves = StaticLeaves;
-            StaticTree.GetOverlaps(min, max, ref enumerator);
+            StaticTree.GetOverlaps(min, max, pool, ref enumerator);
             //Enumeration could have mutated the enumerator; preserve those modifications.
             overlapEnumerator = enumerator.Enumerator;
         }
@@ -136,15 +140,16 @@ namespace BepuPhysics.CollisionDetection
         /// </summary>
         /// <typeparam name="TOverlapEnumerator">Type of the enumerator to call for overlaps.</typeparam>
         /// <param name="boundingBox">Query box bounds.</param>
+        /// <param name="pool">Pool used for temporary allocations required by the test, if any.</param>
         /// <param name="overlapEnumerator">Enumerator to call for overlaps.</param>
-        public void GetOverlaps<TOverlapEnumerator>(in BoundingBox boundingBox, ref TOverlapEnumerator overlapEnumerator) where TOverlapEnumerator : IBreakableForEach<CollidableReference>
+        public void GetOverlaps<TOverlapEnumerator>(in BoundingBox boundingBox, BufferPool pool, ref TOverlapEnumerator overlapEnumerator) where TOverlapEnumerator : IBreakableForEach<CollidableReference>
         {
             BoxQueryEnumerator<TOverlapEnumerator> enumerator;
             enumerator.Enumerator = overlapEnumerator;
             enumerator.Leaves = ActiveLeaves;
-            ActiveTree.GetOverlaps(boundingBox, ref enumerator);
+            ActiveTree.GetOverlaps(boundingBox, pool, ref enumerator);
             enumerator.Leaves = StaticLeaves;
-            StaticTree.GetOverlaps(boundingBox, ref enumerator);
+            StaticTree.GetOverlaps(boundingBox, pool, ref enumerator);
             //Enumeration could have mutated the enumerator; preserve those modifications.
             overlapEnumerator = enumerator.Enumerator;
         }

--- a/BepuPhysics/CollisionDetection/MeshReduction.cs
+++ b/BepuPhysics/CollisionDetection/MeshReduction.cs
@@ -445,7 +445,7 @@ namespace BepuPhysics.CollisionDetection
                         var contactQueryMin = meshSpaceContact - contactExpansion;
                         var contactQueryMax = meshSpaceContact + contactExpansion;
                         enumerator.List.Count = 0;
-                        mesh->Tree.GetOverlaps(contactQueryMin, contactQueryMax, ref enumerator);
+                        mesh->Tree.GetOverlaps(contactQueryMin, contactQueryMax, pool, ref enumerator);
                         //Note that the test triangles detected by querying may exceed the count in extremely rare cases, so it's not safe to use AllocateUnsafely without some extra work.
                         //Resizing invalidates table indices, so do any that ahead of time.
                         testTriangles.EnsureCapacity(testTriangles.Count + enumerator.List.Count, pool);

--- a/BepuPhysics/CollisionDetection/RayBatchers.cs
+++ b/BepuPhysics/CollisionDetection/RayBatchers.cs
@@ -9,11 +9,11 @@ namespace BepuPhysics.CollisionDetection
 {
     public interface IBroadPhaseRayTester
     {
-        unsafe void RayTest(CollidableReference collidable, RayData* rayData, float* maximumT);
+        unsafe void RayTest(CollidableReference collidable, RayData* rayData, float* maximumT, BufferPool pool);
     }
     public interface IBroadPhaseBatchedRayTester : IBroadPhaseRayTester
     {
-        void RayTest(CollidableReference collidable, ref RaySource rays);
+        void RayTest(CollidableReference collidable, ref RaySource rays, BufferPool pool);
     }
 
     /// <summary>
@@ -31,15 +31,15 @@ namespace BepuPhysics.CollisionDetection
             public Buffer<CollidableReference> Leaves;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public void RayTest(int leafIndex, ref RaySource rays)
+            public void RayTest(int leafIndex, ref RaySource rays, BufferPool pool)
             {
-                RayTester.RayTest(Leaves[leafIndex], ref rays);
+                RayTester.RayTest(Leaves[leafIndex], ref rays, pool);
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void TestLeaf(int leafIndex, RayData* rayData, float* maximumT)
+            public unsafe void TestLeaf(int leafIndex, RayData* rayData, float* maximumT, BufferPool pool)
             {
-                RayTester.RayTest(Leaves[leafIndex], rayData, maximumT);
+                RayTester.RayTest(Leaves[leafIndex], rayData, maximumT, pool);
             }
         }
 
@@ -138,24 +138,24 @@ namespace BepuPhysics.CollisionDetection
 
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void RayTest(CollidableReference reference, ref RaySource rays)
+            public unsafe void RayTest(CollidableReference reference, ref RaySource rays, BufferPool pool)
             {
                 if (HitHandler.HitHandler.AllowTest(reference))
                 {
                     Simulation.GetPoseAndShape(reference, out var pose, out var shape);
                     HitHandler.Reference = reference;
-                    Simulation.Shapes[shape.Type].RayTest(shape.Index, *pose, ref rays, ref HitHandler);
+                    Simulation.Shapes[shape.Type].RayTest(shape.Index, *pose, ref rays, pool, ref HitHandler);
                 }
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void RayTest(CollidableReference reference, RayData* rayData, float* maximumT)
+            public unsafe void RayTest(CollidableReference reference, RayData* rayData, float* maximumT, BufferPool pool)
             {
                 if (HitHandler.HitHandler.AllowTest(reference))
                 {
                     Simulation.GetPoseAndShape(reference, out var pose, out var shape);
                     HitHandler.Reference = reference;
-                    Simulation.Shapes[shape.Type].RayTest(shape.Index, *pose, *rayData, ref *maximumT, ref HitHandler);
+                    Simulation.Shapes[shape.Type].RayTest(shape.Index, *pose, *rayData, ref *maximumT, pool, ref HitHandler);
                 }
             }
 

--- a/BepuPhysics/Statics.cs
+++ b/BepuPhysics/Statics.cs
@@ -251,7 +251,7 @@ namespace BepuPhysics
             if (filter.AllowAwakening)
             {
                 var collector = new SleepingBodyCollector<TFilter>(bodies, broadPhase, pool, ref filter);
-                broadPhase.StaticTree.GetOverlaps(bounds, ref collector);
+                broadPhase.StaticTree.GetOverlaps(bounds, pool, ref collector);
                 awakener.AwakenSets(ref collector.SleepingSets);
                 //Just in case the filter did some internal mutation, preserve the changes.
                 filter = collector.Filter;

--- a/BepuPhysics/Trees/RayBatcher.cs
+++ b/BepuPhysics/Trees/RayBatcher.cs
@@ -111,11 +111,11 @@ namespace BepuPhysics.Trees
 
     public interface IRayLeafTester
     {
-        unsafe void TestLeaf(int leafIndex, RayData* rayData, float* maximumT);
+        unsafe void TestLeaf(int leafIndex, RayData* rayData, float* maximumT, BufferPool pool);
     }
     public interface IBatchedRayLeafTester : IRayLeafTester
     {
-        void RayTest(int leafIndex, ref RaySource rays);
+        void RayTest(int leafIndex, ref RaySource rays, BufferPool pool);
     }
 
 
@@ -432,9 +432,7 @@ namespace BepuPhysics.Trees
         {
             Debug.Assert(stackPointerA0 == 0 && stackPointerB == 0 && stackPointerA1 == 0 && stackPointer == 0,
                 "At the beginning of the traversal, there should exist no entries on the traversal stack.");
-            Debug.Assert(tree.ComputeMaximumDepth() < fallbackStack.Length, "At the moment, we assume that no tree will have more than 256 levels. " +
-                "This isn't a hard guarantee; if you hit this, please report it- it probably means there is some goofy pathological case badness in the builder or refiner." +
-                "Would be nice to replace this with a properly tracked tree depth so correctness isn't conditional.");
+
             if (tree.LeafCount == 0)
                 return;
 
@@ -511,7 +509,7 @@ namespace BepuPhysics.Trees
                     {
                         //This is a leaf node.
                         var rayStackSource = new RaySource(batchRays.Memory, batchOriginalRays.Memory, rayStackStart, entry.RayCount);
-                        leafTester.RayTest(Tree.Encode(entry.NodeIndex), ref rayStackSource);
+                        leafTester.RayTest(Tree.Encode(entry.NodeIndex), ref rayStackSource, pool);
                     }
                 }
                 else
@@ -520,7 +518,7 @@ namespace BepuPhysics.Trees
                     for (int i = 0; i < entry.RayCount; ++i)
                     {
                         var rayIndex = rayStackStart[i];
-                        tree.RayCast(entry.NodeIndex, batchRays.Memory + rayIndex, batchOriginalRays.Memory + rayIndex, fallbackStack.Memory, ref leafTester);
+                        tree.RayCast(entry.NodeIndex, batchRays.Memory + rayIndex, batchOriginalRays.Memory + rayIndex, fallbackStack, pool, ref leafTester);
                     }
                 }
             }

--- a/BepuPhysics/Trees/Tree_Sweep.cs
+++ b/BepuPhysics/Trees/Tree_Sweep.cs
@@ -1,4 +1,5 @@
 ﻿using BepuUtilities;
+using BepuUtilities.Memory;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -11,7 +12,7 @@ namespace BepuPhysics.Trees
     }
     partial struct Tree
     {
-        readonly unsafe void Sweep<TLeafTester>(int nodeIndex, Vector3 expansion, Vector3 origin, Vector3 direction, TreeRay* treeRay, int* stack, ref TLeafTester leafTester) where TLeafTester : ISweepLeafTester
+        readonly unsafe void Sweep<TLeafTester>(int nodeIndex, Vector3 expansion, Vector3 origin, Vector3 direction, TreeRay* treeRay, Buffer<int> stack, BufferPool pool, ref TLeafTester leafTester) where TLeafTester : ISweepLeafTester
         {
             Debug.Assert((nodeIndex >= 0 && nodeIndex < NodeCount) || (Encode(nodeIndex) >= 0 && Encode(nodeIndex) < LeafCount));
             Debug.Assert(LeafCount >= 2, "This implementation assumes all nodes are filled.");
@@ -26,7 +27,7 @@ namespace BepuPhysics.Trees
                     leafTester.TestLeaf(leafIndex, ref treeRay->MaximumT);
                     //Leaves have no children; have to pull from the stack to get a new target.
                     if (stackEnd == 0)
-                        return;
+                        break;
                     nodeIndex = stack[--stackEnd];
                 }
                 else
@@ -44,7 +45,18 @@ namespace BepuPhysics.Trees
                         if (bIntersected)
                         {
                             //Visit the earlier AABB intersection first.
-                            Debug.Assert(stackEnd < TraversalStackCapacity - 1, "At the moment, we use a fixed size stack. Until we have explicitly tracked depths, watch out for excessive depth traversals.");
+                            if (stackEnd == stack.Length)
+                            {
+                                if (stack.Length == TraversalStackCapacity)
+                                {
+                                    // First allocation is on the stack.
+                                    pool.TakeAtLeast<int>(TraversalStackCapacity * 2, out var newStack);
+                                    stack.CopyTo(0, newStack, 0, TraversalStackCapacity);
+                                    stack = newStack;
+                                }
+                                else
+                                    pool.Resize(ref stack, stackEnd * 2, stackEnd);
+                            }
                             if (tA < tB)
                             {
                                 nodeIndex = node.A.Index;
@@ -70,15 +82,19 @@ namespace BepuPhysics.Trees
                     {
                         //No intersection. Need to pull from the stack to get a new target.
                         if (stackEnd == 0)
-                            return;
+                            break;
                         nodeIndex = stack[--stackEnd];
                     }
                 }
             }
-
+            if (stack.Length > TraversalStackCapacity)
+            {
+                // We rented a larger stack at some point. Return it.
+                pool.Return(ref stack);
+            }
         }
 
-        internal readonly unsafe void Sweep<TLeafTester>(Vector3 expansion, Vector3 origin, Vector3 direction, TreeRay* treeRay, ref TLeafTester sweepTester) where TLeafTester : ISweepLeafTester
+        internal readonly unsafe void Sweep<TLeafTester>(Vector3 expansion, Vector3 origin, Vector3 direction, TreeRay* treeRay, BufferPool pool, ref TLeafTester sweepTester) where TLeafTester : ISweepLeafTester
         {
             if (LeafCount == 0)
                 return;
@@ -93,13 +109,18 @@ namespace BepuPhysics.Trees
             }
             else
             {
-                //TODO: Explicitly tracking depth in the tree during construction/refinement is practically required to guarantee correctness.
-                //While it's exceptionally rare that any tree would have more than 256 levels, the worst case of stomping stack memory is not acceptable in the long run.
                 var stack = stackalloc int[TraversalStackCapacity];
-                Sweep(0, expansion, origin, direction, treeRay, stack, ref sweepTester);
+                Sweep(0, expansion, origin, direction, treeRay, new Buffer<int>(stack, TraversalStackCapacity), pool, ref sweepTester);
             }
         }
 
+        /// <summary>
+        /// Converts a bounding box defined by minimum and maximum corners into a centroid and half-extent representation.
+        /// </summary>
+        /// <param name="min">The minimum corner of the bounding box.</param>
+        /// <param name="max">The maximum corner of the bounding box.</param>
+        /// <param name="origin">The computed centroid of the bounding box.</param>
+        /// <param name="expansion">The computed half-extents of the bounding box.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ConvertBoxToCentroidWithExtent(Vector3 min, Vector3 max, out Vector3 origin, out Vector3 expansion)
         {
@@ -109,16 +130,35 @@ namespace BepuPhysics.Trees
             origin = halfMax + halfMin;
         }
 
-        public readonly unsafe void Sweep<TLeafTester>(Vector3 min, Vector3 max, Vector3 direction, float maximumT, ref TLeafTester sweepTester) where TLeafTester : ISweepLeafTester
+        /// <summary>
+        /// Performs a sweep test of an axis-aligned bounding box against the tree and invokes the <paramref name="sweepTester"/> for each intersecting leaf.
+        /// </summary>
+        /// <typeparam name="TLeafTester">The type of the <see cref="ISweepLeafTester"/> used to process the intersecting leaves.</typeparam>
+        /// <param name="min">The minimum corner of the axis-aligned bounding box to sweep.</param>
+        /// <param name="max">The maximum corner of the axis-aligned bounding box to sweep.</param>
+        /// <param name="direction">The direction of the sweep.</param>
+        /// <param name="maximumT">The maximum parametric distance along the sweep direction to test.</param>
+        /// <param name="sweepTester">A reference to the tester that processes the indices of intersecting leaves.</param>
+        /// <param name="pool">The buffer pool used for temporary allocations during the operation. Only used if the tree is pathologically deep; stack memory is used preferentially.</param>
+        public readonly unsafe void Sweep<TLeafTester>(Vector3 min, Vector3 max, Vector3 direction, float maximumT, BufferPool pool, ref TLeafTester sweepTester) where TLeafTester : ISweepLeafTester
         {
             ConvertBoxToCentroidWithExtent(min, max, out var origin, out var expansion);
             TreeRay.CreateFrom(origin, direction, maximumT, out var treeRay);
-            Sweep(expansion, origin, direction, &treeRay, ref sweepTester);
+            Sweep(expansion, origin, direction, &treeRay, pool, ref sweepTester);
         }
+        /// <summary>
+        /// Performs a sweep test of a bounding box against the tree and invokes the <paramref name="sweepTester"/> for each intersecting leaf.
+        /// </summary>
+        /// <typeparam name="TLeafTester">The type of the <see cref="ISweepLeafTester"/> used to process the intersecting leaves.</typeparam>
+        /// <param name="boundingBox">The bounding box to sweep.</param>
+        /// <param name="direction">The direction of the sweep.</param>
+        /// <param name="maximumT">The maximum parametric distance along the sweep direction to test.</param>
+        /// <param name="sweepTester">A reference to the tester that processes the indices of intersecting leaves.</param>
+        /// <param name="pool">The buffer pool used for temporary allocations during the operation. Only used if the tree is pathologically deep; stack memory is used preferentially.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public readonly void Sweep<TLeafTester>(in BoundingBox boundingBox, Vector3 direction, float maximumT, ref TLeafTester sweepTester) where TLeafTester : ISweepLeafTester
+        public readonly void Sweep<TLeafTester>(in BoundingBox boundingBox, Vector3 direction, float maximumT, BufferPool pool, ref TLeafTester sweepTester) where TLeafTester : ISweepLeafTester
         {
-            Sweep(boundingBox.Min, boundingBox.Max, direction, maximumT, ref sweepTester);
+            Sweep(boundingBox.Min, boundingBox.Max, direction, maximumT, pool, ref sweepTester);
         }
 
     }

--- a/DemoBenchmarks/ShapeRayBenchmarksDeep.cs
+++ b/DemoBenchmarks/ShapeRayBenchmarksDeep.cs
@@ -82,7 +82,7 @@ public class ShapeRayBenchmarksDeep
         {
             ref var iteration = ref iterations[i];
             float maximumT = float.MaxValue;
-            shapes[TShape.TypeId].RayTest(0, iteration.Pose, iteration.Ray, ref maximumT, ref hitHandler);
+            shapes[TShape.TypeId].RayTest(0, iteration.Pose, iteration.Ray, ref maximumT, pool, ref hitHandler);
         }
         return hitHandler.ResultSum;
     }

--- a/DemoTests/InertiaTensorTests.cs
+++ b/DemoTests/InertiaTensorTests.cs
@@ -311,7 +311,7 @@ namespace DemoTests
                     {
                         var sampleLocation = sampleMin + new Vector3(i, j, k) * sampleSpacing;
                         var previousCount = hitCounter.Counter;
-                        compound.RayTest(pose, new RayData { Origin = sampleLocation, Direction = Vector3.UnitY }, ref maximumT, shapes, ref hitCounter);
+                        compound.RayTest(pose, new RayData { Origin = sampleLocation, Direction = Vector3.UnitY }, ref maximumT, shapes, pool, ref hitCounter);
                         //If the ray hit more than one shape, then we count them all.
                         //This matches how the analytic inertia is calculated- every shape provides its own tensor, and they're summed.
                         //(Notably, if you wanted non-overlapping inertia, this is counterproductive!)

--- a/Demos/DemoHarness.cs
+++ b/Demos/DemoHarness.cs
@@ -268,7 +268,7 @@ public class DemoHarness : IDisposable
                 incrementalGrabRotation = Quaternion.Identity;
                 grabberCachedMousePosition = null;
             }
-            grabber.Update(demo.Simulation, camera, input.MouseLocked, controls.Grab.IsDown(input), incrementalGrabRotation, window.GetNormalizedMousePosition(input.MousePosition));
+            grabber.Update(demo.Simulation, camera, input.MouseLocked, controls.Grab.IsDown(input), incrementalGrabRotation, window.GetNormalizedMousePosition(input.MousePosition), demo.BufferPool);
 
 
 

--- a/Demos/Demos/CollisionQueryDemo.cs
+++ b/Demos/Demos/CollisionQueryDemo.cs
@@ -138,7 +138,7 @@ public class CollisionQueryDemo : Demo
     public unsafe void AddQueryToBatch(int queryShapeType, void* queryShapeData, int queryShapeSize, Vector3 queryBoundsMin, Vector3 queryBoundsMax, in RigidPose queryPose, int queryId, ref CollisionBatcher<BatcherCallbacks> batcher)
     {
         var broadPhaseEnumerator = new BroadPhaseOverlapEnumerator { Pool = BufferPool, References = new QuickList<CollidableReference>(16, BufferPool) };
-        Simulation.BroadPhase.GetOverlaps(queryBoundsMin, queryBoundsMax, ref broadPhaseEnumerator);
+        Simulation.BroadPhase.GetOverlaps(queryBoundsMin, queryBoundsMax, BufferPool, ref broadPhaseEnumerator);
         for (int overlapIndex = 0; overlapIndex < broadPhaseEnumerator.References.Count; ++overlapIndex)
         {
             GetPoseAndShape(broadPhaseEnumerator.References[overlapIndex], out var pose, out var shapeIndex);
@@ -188,7 +188,7 @@ public class CollisionQueryDemo : Demo
         shapeBatch.ComputeBounds(queryShapeIndex.Index, queryPose, out var queryBoundsMin, out var queryBoundsMax);
         Simulation.Shapes[queryShapeIndex.Type].GetShapeData(queryShapeIndex.Index, out var queryShapeData, out _);
         var broadPhaseEnumerator = new BroadPhaseOverlapEnumerator { Pool = BufferPool, References = new QuickList<CollidableReference>(16, BufferPool) };
-        Simulation.BroadPhase.GetOverlaps(queryBoundsMin, queryBoundsMax, ref broadPhaseEnumerator);
+        Simulation.BroadPhase.GetOverlaps(queryBoundsMin, queryBoundsMax, BufferPool, ref broadPhaseEnumerator);
         for (int overlapIndex = 0; overlapIndex < broadPhaseEnumerator.References.Count; ++overlapIndex)
         {
             GetPoseAndShape(broadPhaseEnumerator.References[overlapIndex], out var pose, out var shapeIndex);

--- a/Demos/Demos/RayCastingDemo.cs
+++ b/Demos/Demos/RayCastingDemo.cs
@@ -319,13 +319,14 @@ public class RayCastingDemo : Demo
         int intersectionCount = 0;
         var hitHandler = new HitHandler { Hits = algorithm.Results, IntersectionCount = &intersectionCount };
         int claimedIndex;
+        var pool = ThreadDispatcher.WorkerPools[workerIndex];
         while ((claimedIndex = Interlocked.Increment(ref algorithm.JobIndex)) < jobs.Length)
         {
             ref var job = ref jobs[claimedIndex];
             for (int i = job.Start; i < job.End; ++i)
             {
                 ref var ray = ref testRays[i];
-                Simulation.RayCast(ray.Origin, ray.Direction, ray.MaximumT, ref hitHandler, i);
+                Simulation.RayCast(ray.Origin, ray.Direction, ray.MaximumT, pool, ref hitHandler, i);
             }
         }
         return intersectionCount;

--- a/Demos/Grabber.cs
+++ b/Demos/Grabber.cs
@@ -3,6 +3,7 @@ using BepuPhysics.Collidables;
 using BepuPhysics.Constraints;
 using BepuPhysics.Trees;
 using BepuUtilities;
+using BepuUtilities.Memory;
 using DemoRenderer;
 using DemoRenderer.Constraints;
 using System;
@@ -66,7 +67,7 @@ struct Grabber
         };
     }
 
-    public void Update(Simulation simulation, Camera camera, bool mouseLocked, bool shouldGrab, Quaternion rotation, in Vector2 normalizedMousePosition)
+    public void Update(Simulation simulation, Camera camera, bool mouseLocked, bool shouldGrab, Quaternion rotation, in Vector2 normalizedMousePosition, BufferPool pool)
     {
         //On the off chance some demo modifies the kinematic state, treat that as a grab terminator.
         var bodyExists = body.Exists && !body.Kinematic;
@@ -88,7 +89,7 @@ struct Grabber
             var rayDirection = camera.GetRayDirection(mouseLocked, normalizedMousePosition);
             var hitHandler = default(RayHitHandler);
             hitHandler.T = float.MaxValue;
-            simulation.RayCast(camera.Position, rayDirection, float.MaxValue, ref hitHandler);
+            simulation.RayCast(camera.Position, rayDirection, float.MaxValue, pool, ref hitHandler);
             if (hitHandler.T < float.MaxValue && hitHandler.HitCollidable.Mobility == CollidableMobility.Dynamic)
             {
                 //Found something to grab!

--- a/Demos/SpecializedTests/IntertreeThreadingTests.cs
+++ b/Demos/SpecializedTests/IntertreeThreadingTests.cs
@@ -139,7 +139,7 @@ public static class IntertreeThreadingTests
         {
             GetBoundsForLeaf(smaller, i, out var bounds);
             bruteResultsEnumerator.QuerySourceIndex = i;
-            larger.GetOverlaps(bounds, ref bruteResultsEnumerator);
+            larger.GetOverlaps(bounds, pool, ref bruteResultsEnumerator);
         }
         SortPairs(bruteResultsEnumerator.Pairs);
 

--- a/Demos/SpecializedTests/VolumeQueryTests.cs
+++ b/Demos/SpecializedTests/VolumeQueryTests.cs
@@ -177,13 +177,14 @@ public class VolumeQueryTests : Demo
         int intersectionCount = 0;
         var hitHandler = new HitHandler { IntersectionCount = &intersectionCount };
         int claimedIndex;
+        var pool = ThreadDispatcher.WorkerPools[workerIndex];
         while ((claimedIndex = Interlocked.Increment(ref algorithm.JobIndex)) < jobs.Length)
         {
             ref var job = ref jobs[claimedIndex];
             for (int i = job.Start; i < job.End; ++i)
             {
                 ref var box = ref queryBoxes[i];
-                Simulation.BroadPhase.GetOverlaps(box, ref hitHandler);
+                Simulation.BroadPhase.GetOverlaps(box, pool, ref hitHandler);
             }
         }
         return intersectionCount;


### PR DESCRIPTION
Historically, a few queries on `Tree` assumed a maximum possible depth. It was guarded by debug asserts. It was not guarded at runtime.

Simultaneously, there were pathological cases where the tree could become more like a linked list.

That's bad!

#380 and #375 fixed the so-far-observed paths to degeneracy in a tree, but having a stack overrun at runtime should not be a thing that's logically accessible!

With the unfortunate side effect of requiring `BufferPool`s in a whole lotta places, the tree query paths will no longer explode in release mode if the tree gets really badly screwed up. Queries still default to using stack allocations, so the performance impact of this change is minimal (just a bunch of trivially predictable branches).