### PR TITLE
Demo window shouldn't eat the mouse cursor

### DIFF
--- a/DemoUtilities/Input.cs
+++ b/DemoUtilities/Input.cs
@@ -238,11 +238,11 @@ namespace DemoUtilities
                 //This is pretty doofy, but it works reasonably well and we don't have easy access to the windows-provided capture stuff through opentk (that I'm aware of?).
                 //Could change it later if it matters, but realistically it won't matter.
                 MousePosition = WindowCenter;
-                window.CursorVisible = false;
+                if (window.CursorVisible) window.CursorVisible = false;
             }
             else
             {
-                window.CursorVisible = true;
+                if (!window.CursorVisible) window.CursorVisible = true;
             }
 
         }


### PR DESCRIPTION
For some reason, on some systems under unidentified conditions, setting the `CursorVisible` every frame grabs onto the mouse and doesn't let it leave the window. So don't do that. 