### PR TITLE
MeshReduction for not-just-`Mesh`

### DIFF
--- a/BepuPhysics/Collidables/BigCompound.cs
+++ b/BepuPhysics/Collidables/BigCompound.cs
@@ -305,6 +305,13 @@ namespace BepuPhysics.Collidables
             Tree.Sweep(min, max, sweep, maximumT, pool, ref enumerator);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly void FindLocalOverlaps<TEnumerator>(Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref TEnumerator enumerator)
+            where TEnumerator : IBreakableForEach<int>
+        {
+            Tree.GetOverlaps(min, max, pool, ref enumerator);
+        }
+
         /// <summary>
         /// Computes the inertia of a compound. Does not recenter the child poses.
         /// </summary>

--- a/BepuPhysics/Collidables/Compound.cs
+++ b/BepuPhysics/Collidables/Compound.cs
@@ -336,6 +336,24 @@ public struct Compound : ICompoundShape
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void FindLocalOverlaps<TEnumerator>(Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref TEnumerator enumerator)
+        where TEnumerator : IBreakableForEach<int>
+    {
+        for (int i = 0; i < Children.Length; ++i)
+        {
+            ref var child = ref Children[i];
+            shapes[child.ShapeIndex.Type].ComputeBounds(child.ShapeIndex.Index, child.LocalOrientation, out _, out _, out var childMin, out var childMax);
+            childMin += child.LocalPosition;
+            childMax += child.LocalPosition;
+            if (BoundingBox.Intersects(childMin, childMax, min, max))
+            {
+                if (!enumerator.LoopBody(i))
+                    return;
+            }
+        }
+    }
+
     public unsafe void FindLocalOverlaps<TOverlaps>(Vector3 min, Vector3 max, Vector3 sweep, float maximumT, BufferPool pool, Shapes shapes, void* overlapsPointer)
         where TOverlaps : ICollisionTaskSubpairOverlaps
     {

--- a/BepuPhysics/Collidables/Mesh.cs
+++ b/BepuPhysics/Collidables/Mesh.cs
@@ -371,6 +371,17 @@ namespace BepuPhysics.Collidables
             Tree.Sweep(Vector3.Min(scaledMin, scaledMax), Vector3.Max(scaledMin, scaledMax), scaledSweep, maximumT, pool, ref enumerator);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly void FindLocalOverlaps<TEnumerator>(Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref TEnumerator enumerator)
+            where TEnumerator : IBreakableForEach<int>
+        {
+            //The tree is built from unscaled source triangles, so the query AABB has to be brought into unscaled space.
+            //Take a min/max to compensate for negative scales.
+            var scaledMin = min * inverseScale;
+            var scaledMax = max * inverseScale;
+            Tree.GetOverlaps(Vector3.Min(scaledMin, scaledMax), Vector3.Max(scaledMin, scaledMax), pool, ref enumerator);
+        }
+
         public struct MeshTriangleSource : ITriangleSource
         {
             Mesh mesh;

--- a/BepuPhysics/CollisionDetection/CollisionTasks/CompoundMeshContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/CompoundMeshContinuations.cs
@@ -6,8 +6,8 @@ using System.Runtime.CompilerServices;
 namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public unsafe struct CompoundMeshContinuations<TCompound, TMesh> : ICompoundPairContinuationHandler<CompoundMeshReduction>
-        where TCompound : ICompoundShape
-        where TMesh : IHomogeneousCompoundShape<Triangle, TriangleWide>
+        where TCompound : struct, ICompoundShape
+        where TMesh : struct, IHomogeneousCompoundShape<Triangle, TriangleWide>
     {
         public CollisionContinuationType CollisionContinuationType => CollisionContinuationType.CompoundMeshReduction;
 
@@ -23,8 +23,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             collisionBatcher.Pool.Take(pairOverlaps.Length, out continuation.QueryBounds);
             continuation.RegionCount = pairOverlaps.Length;
             continuation.MeshOrientation = pair.OrientationB;
-            //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
-            continuation.Mesh = (Mesh*)pair.B;
+            continuation.Mesh = pair.B;
+            continuation.FindLocalOverlapsThunk = MeshReductionThunks<TMesh>.FindLocalOverlaps;
+            continuation.GetLocalChildThunk = MeshReductionThunks<TMesh>.GetLocalChild;
             //A flip is required in mesh reduction whenever contacts are being generated as if the triangle is in slot B, which is whenever this pair has *not* been flipped.
             continuation.RequiresFlip = pair.FlipMask == 0;
 

--- a/BepuPhysics/CollisionDetection/CollisionTasks/ConvexCompoundOverlapFinder.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/ConvexCompoundOverlapFinder.cs
@@ -21,6 +21,18 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
 
         void FindLocalOverlaps<TOverlaps>(Vector3 min, Vector3 max, Vector3 sweep, float maximumT, BufferPool pool, Shapes shapes, void* overlaps)
             where TOverlaps : ICollisionTaskSubpairOverlaps;
+
+        /// <summary>
+        /// Finds the indices of all children whose local-space bounding boxes overlap the given local-space AABB.
+        /// </summary>
+        /// <typeparam name="TEnumerator">Type of the enumerator that receives child indices.</typeparam>
+        /// <param name="min">Minimum corner of the query AABB in the compound's local space.</param>
+        /// <param name="max">Maximum corner of the query AABB in the compound's local space.</param>
+        /// <param name="pool">Pool used for any temporary allocations during traversal.</param>
+        /// <param name="shapes">Shape collection used to look up child bounds for compounds with heterogeneous children. May be null for homogeneous compounds that don't require it.</param>
+        /// <param name="enumerator">Enumerator that receives the indices of overlapping children.</param>
+        void FindLocalOverlaps<TEnumerator>(Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref TEnumerator enumerator)
+            where TEnumerator : IBreakableForEach<int>;
     }
     public interface IConvexCompoundOverlapFinder
     {

--- a/BepuPhysics/CollisionDetection/CollisionTasks/ConvexMeshContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/ConvexMeshContinuations.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
-    public struct ConvexMeshContinuations<TMesh> : IConvexCompoundContinuationHandler<MeshReduction> where TMesh : IHomogeneousCompoundShape<Triangle, TriangleWide>
+    public struct ConvexMeshContinuations<TMesh> : IConvexCompoundContinuationHandler<MeshReduction> where TMesh : struct, IHomogeneousCompoundShape<Triangle, TriangleWide>
     {
         public CollisionContinuationType CollisionContinuationType => CollisionContinuationType.MeshReduction;
 
@@ -20,8 +20,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             continuation.RequiresFlip = pair.FlipMask == 0;
             continuation.QueryBounds.Min = pairQuery.Min;
             continuation.QueryBounds.Max = pairQuery.Max;
-            //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
             continuation.Mesh = pairQuery.Container;
+            continuation.FindLocalOverlapsThunk = MeshReductionThunks<TMesh>.FindLocalOverlaps;
+            continuation.GetLocalChildThunk = MeshReductionThunks<TMesh>.GetLocalChild;
             return ref continuation;
         }
 

--- a/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionTasks/MeshPairContinuations.cs
@@ -6,8 +6,8 @@ using System.Runtime.CompilerServices;
 namespace BepuPhysics.CollisionDetection.CollisionTasks
 {
     public unsafe struct MeshPairContinuations<TMeshA, TMeshB> : ICompoundPairContinuationHandler<CompoundMeshReduction>
-        where TMeshA : IHomogeneousCompoundShape<Triangle, TriangleWide>
-        where TMeshB : IHomogeneousCompoundShape<Triangle, TriangleWide>
+        where TMeshA : struct, IHomogeneousCompoundShape<Triangle, TriangleWide>
+        where TMeshB : struct, IHomogeneousCompoundShape<Triangle, TriangleWide>
     {
         public CollisionContinuationType CollisionContinuationType => CollisionContinuationType.CompoundMeshReduction;
 
@@ -29,8 +29,9 @@ namespace BepuPhysics.CollisionDetection.CollisionTasks
             continuation.MeshOrientation = pair.OrientationB;
             //A flip is required in mesh reduction whenever contacts are being generated as if the triangle is in slot B, which is whenever this pair has *not* been flipped.
             continuation.RequiresFlip = pair.FlipMask == 0;
-            //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
-            continuation.Mesh = (Mesh*)pair.B;
+            continuation.Mesh = pair.B;
+            continuation.FindLocalOverlapsThunk = MeshReductionThunks<TMeshB>.FindLocalOverlaps;
+            continuation.GetLocalChildThunk = MeshReductionThunks<TMeshB>.GetLocalChild;
 
             //All regions must be assigned ahead of time. Some trailing regions may be empty, so the dispatch may occur before all children are visited in the later loop.
             //That would result in potentially uninitialized values in region counts.

--- a/BepuPhysics/CollisionDetection/CompoundMeshReduction.cs
+++ b/BepuPhysics/CollisionDetection/CompoundMeshReduction.cs
@@ -21,7 +21,10 @@ namespace BepuPhysics.CollisionDetection
         //This uses all of the nonconvex reduction's logic, so we just nest it.
         public NonconvexReduction Inner;
 
-        public Mesh* Mesh; //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
+        //Type-erased mesh pointer plus the per-TMesh thunks. See MeshReduction for the rationale.
+        public void* Mesh;
+        public delegate*<void*, Vector3, Vector3, BufferPool, Shapes, ref MeshReduction.ChildEnumerator, void> FindLocalOverlapsThunk;
+        public delegate*<void*, int, out Triangle, void> GetLocalChildThunk;
 
         public void Create(int childManifoldCount, BufferPool pool)
         {
@@ -54,7 +57,8 @@ namespace BepuPhysics.CollisionDetection
                     ref var region = ref ChildManifoldRegions[i];
                     if (region.Count > 0)
                     {
-                        MeshReduction.ReduceManifolds(ref Triangles, ref Inner.Children, region.Start, region.Count, RequiresFlip, QueryBounds[i], meshOrientation, meshInverseOrientation, Mesh, batcher.Pool);
+                        MeshReduction.ReduceManifolds(ref Triangles, ref Inner.Children, region.Start, region.Count, RequiresFlip, QueryBounds[i], meshOrientation, meshInverseOrientation,
+                            Mesh, FindLocalOverlapsThunk, GetLocalChildThunk, batcher.Shapes, batcher.Pool);
                     }
                 }
 

--- a/BepuPhysics/CollisionDetection/MeshReduction.cs
+++ b/BepuPhysics/CollisionDetection/MeshReduction.cs
@@ -32,7 +32,7 @@ namespace BepuPhysics.CollisionDetection
         //Type-erased pointer to the mesh shape data, plus two function pointers that close over the concrete mesh type.
         //ConvexMeshContinuations<TMesh> populates these from MeshReductionThunks<TMesh> at continuation creation time.
         //The thunks are static methods of a generic helper, so they're JIT-specialized per TMesh and any interface
-        //call inside them is devirtualized. This keeps the >=128 path's per-contact calls cheap without requiring
+        //call inside them is devirtualized. This keeps the 'way too many subpairs' path's per-contact calls cheap without requiring
         //CollisionBatcher to know about TMesh.
         public void* Mesh;
         public delegate*<void*, Vector3, Vector3, BufferPool, Shapes, ref ChildEnumerator, void> FindLocalOverlapsThunk;

--- a/BepuPhysics/CollisionDetection/MeshReduction.cs
+++ b/BepuPhysics/CollisionDetection/MeshReduction.cs
@@ -445,7 +445,12 @@ namespace BepuPhysics.CollisionDetection
                         var contactQueryMin = meshSpaceContact - contactExpansion;
                         var contactQueryMax = meshSpaceContact + contactExpansion;
                         enumerator.List.Count = 0;
-                        mesh->Tree.GetOverlaps(contactQueryMin, contactQueryMax, pool, ref enumerator);
+                        //The contact and the cached TestTriangle data live in scaled mesh-local space (GetLocalChild applies the mesh's scale),
+                        //but the Tree was built from unscaled source triangles. Bring the query into the tree's space before traversing.
+                        //Take min/max after scaling to compensate for negative scales.
+                        var scaledQueryMin = contactQueryMin * mesh->inverseScale;
+                        var scaledQueryMax = contactQueryMax * mesh->inverseScale;
+                        mesh->Tree.GetOverlaps(Vector3.Min(scaledQueryMin, scaledQueryMax), Vector3.Max(scaledQueryMin, scaledQueryMax), pool, ref enumerator);
                         //Note that the test triangles detected by querying may exceed the count in extremely rare cases, so it's not safe to use AllocateUnsafely without some extra work.
                         //Resizing invalidates table indices, so do any that ahead of time.
                         testTriangles.EnsureCapacity(testTriangles.Count + enumerator.List.Count, pool);

--- a/BepuPhysics/CollisionDetection/MeshReduction.cs
+++ b/BepuPhysics/CollisionDetection/MeshReduction.cs
@@ -29,7 +29,14 @@ namespace BepuPhysics.CollisionDetection
         //This uses all of the nonconvex reduction's logic, so we just nest it.
         public NonconvexReduction Inner;
 
-        public void* Mesh; //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
+        //Type-erased pointer to the mesh shape data, plus two function pointers that close over the concrete mesh type.
+        //ConvexMeshContinuations<TMesh> populates these from MeshReductionThunks<TMesh> at continuation creation time.
+        //The thunks are static methods of a generic helper, so they're JIT-specialized per TMesh and any interface
+        //call inside them is devirtualized. This keeps the >=128 path's per-contact calls cheap without requiring
+        //CollisionBatcher to know about TMesh.
+        public void* Mesh;
+        public delegate*<void*, Vector3, Vector3, BufferPool, Shapes, ref ChildEnumerator, void> FindLocalOverlapsThunk;
+        public delegate*<void*, int, out Triangle, void> GetLocalChildThunk;
 
         public void Create(int childManifoldCount, BufferPool pool)
         {
@@ -280,7 +287,7 @@ namespace BepuPhysics.CollisionDetection
             }
         }
 
-        struct ChildEnumerator : IBreakableForEach<int>
+        public struct ChildEnumerator : IBreakableForEach<int>
         {
             public QuickList<int> List;
             public BufferPool Pool;
@@ -292,7 +299,11 @@ namespace BepuPhysics.CollisionDetection
         }
 
         public static void ReduceManifolds(ref Buffer<Triangle> continuationTriangles, ref Buffer<NonconvexReductionChild> continuationChildren, int start, int count,
-           bool requiresFlip, in BoundingBox queryBounds, in Matrix3x3 meshOrientation, in Matrix3x3 meshInverseOrientation, Mesh* mesh, BufferPool pool)
+           bool requiresFlip, in BoundingBox queryBounds, in Matrix3x3 meshOrientation, in Matrix3x3 meshInverseOrientation,
+           void* mesh,
+           delegate*<void*, Vector3, Vector3, BufferPool, Shapes, ref ChildEnumerator, void> findLocalOverlapsThunk,
+           delegate*<void*, int, out Triangle, void> getLocalChildThunk,
+           Shapes shapes, BufferPool pool)
         {
             //Before handing responsibility off to the nonconvex reduction, make sure that no contacts create nasty 'bumps' at the border of triangles.
             //Bumps can occur when an isolated triangle test detects a contact pointing outward, like when a box hits the side. This is fine when the triangle truly is isolated,
@@ -445,12 +456,9 @@ namespace BepuPhysics.CollisionDetection
                         var contactQueryMin = meshSpaceContact - contactExpansion;
                         var contactQueryMax = meshSpaceContact + contactExpansion;
                         enumerator.List.Count = 0;
-                        //The contact and the cached TestTriangle data live in scaled mesh-local space (GetLocalChild applies the mesh's scale),
-                        //but the Tree was built from unscaled source triangles. Bring the query into the tree's space before traversing.
-                        //Take min/max after scaling to compensate for negative scales.
-                        var scaledQueryMin = contactQueryMin * mesh->inverseScale;
-                        var scaledQueryMax = contactQueryMax * mesh->inverseScale;
-                        mesh->Tree.GetOverlaps(Vector3.Min(scaledQueryMin, scaledQueryMax), Vector3.Max(scaledQueryMin, scaledQueryMax), pool, ref enumerator);
+                        //The thunk takes coordinates in the same space as the cached TestTriangle data (i.e. the space GetLocalChild returns),
+                        //and is responsible for any internal coordinate-space conversion (e.g. Mesh applies its inverse scale before traversing the tree).
+                        findLocalOverlapsThunk(mesh, contactQueryMin, contactQueryMax, pool, shapes, ref enumerator);
                         //Note that the test triangles detected by querying may exceed the count in extremely rare cases, so it's not safe to use AllocateUnsafely without some extra work.
                         //Resizing invalidates table indices, so do any that ahead of time.
                         testTriangles.EnsureCapacity(testTriangles.Count + enumerator.List.Count, pool);
@@ -464,7 +472,7 @@ namespace BepuPhysics.CollisionDetection
                                 //1) in the long term, the mesh type will be abstracted away, and we might be dealing with a type that doesn't have a Triangles buffer at all.
                                 //2) the Mesh applies a scale to the stored triangles! That's why we have the continuation triangles explicitly stored rather than just looking them all up in the mesh-
                                 //the convex-triangle tests that preceded this reduction had to have somewhere they could load the 'baked' triangle data from.
-                                mesh->GetLocalChild(triangleIndexInMesh, out var triangle);
+                                getLocalChildThunk(mesh, triangleIndexInMesh, out var triangle);
                                 testTriangles.Values[triangleIndex] = new TestTriangle(triangle, triangleIndex);
                             }
                             ref var targetTriangle = ref testTriangles.Values[triangleIndex];
@@ -519,8 +527,8 @@ namespace BepuPhysics.CollisionDetection
             {
                 Matrix3x3.CreateFromQuaternion(MeshOrientation, out var meshOrientation);
                 Matrix3x3.Transpose(meshOrientation, out var meshInverseOrientation);
-                //TODO: This is not flexible with respect to different mesh types. Not a problem right now, but it will be in the future.
-                ReduceManifolds(ref Triangles, ref Inner.Children, 0, Inner.ChildCount, RequiresFlip, QueryBounds, meshOrientation, meshInverseOrientation, (Mesh*)Mesh, batcher.Pool);
+                ReduceManifolds(ref Triangles, ref Inner.Children, 0, Inner.ChildCount, RequiresFlip, QueryBounds, meshOrientation, meshInverseOrientation,
+                    Mesh, FindLocalOverlapsThunk, GetLocalChildThunk, batcher.Shapes, batcher.Pool);
 
                 //Now that boundary smoothing analysis is done, we no longer need the triangle list.
                 batcher.Pool.Return(ref Triangles);
@@ -530,5 +538,29 @@ namespace BepuPhysics.CollisionDetection
             return false;
         }
 
+    }
+
+    /// <summary>
+    /// Type-specialized thunks that bridge MeshReduction's type-erased function pointer fields back to a concrete mesh shape type.
+    /// The static fields here are populated once per closed TMesh by the runtime, and the JIT specializes the bodies so that
+    /// the calls into <typeparamref name="TMesh"/> are devirtualized.
+    /// </summary>
+    /// <typeparam name="TMesh">Concrete homogeneous triangle compound shape type.</typeparam>
+    public static unsafe class MeshReductionThunks<TMesh> where TMesh : struct, IHomogeneousCompoundShape<Triangle, TriangleWide>
+    {
+        public static readonly delegate*<void*, Vector3, Vector3, BufferPool, Shapes, ref MeshReduction.ChildEnumerator, void> FindLocalOverlaps = &FindLocalOverlapsImpl;
+        public static readonly delegate*<void*, int, out Triangle, void> GetLocalChild = &GetLocalChildImpl;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void FindLocalOverlapsImpl(void* mesh, Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref MeshReduction.ChildEnumerator enumerator)
+        {
+            Unsafe.AsRef<TMesh>(mesh).FindLocalOverlaps(min, max, pool, shapes, ref enumerator);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void GetLocalChildImpl(void* mesh, int childIndex, out Triangle triangle)
+        {
+            Unsafe.AsRef<TMesh>(mesh).GetLocalChild(childIndex, out triangle);
+        }
     }
 }

--- a/Demos/Demos/CustomVoxelCollidableDemo.cs
+++ b/Demos/Demos/CustomVoxelCollidableDemo.cs
@@ -108,7 +108,6 @@ struct Voxels : IHomogeneousCompoundShape<Box, BoxWide>
         public Matrix3x3 Orientation;
         public RayData OriginalRay;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void TestLeaf(int leafIndex, RayData* ray, float* maximumT, BufferPool pool)
         {
             ref var voxelIndex = ref VoxelIndices[leafIndex];
@@ -179,7 +178,6 @@ struct Voxels : IHomogeneousCompoundShape<Box, BoxWide>
         hitHandler = leafTester.HitHandler;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly void GetLocalChild(int childIndex, out Box childShape)
     {
         var halfSize = VoxelSize * 0.5f;
@@ -188,14 +186,12 @@ struct Voxels : IHomogeneousCompoundShape<Box, BoxWide>
         childShape.HalfLength = halfSize.Z;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly void GetPosedLocalChild(int childIndex, out Box childShape, out RigidPose childPose)
     {
         GetLocalChild(childIndex, out childShape);
         childPose = (VoxelIndices[childIndex] + new Vector3(0.5f) * VoxelSize);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly void GetLocalChild(int childIndex, ref BoxWide shapeWide)
     {
         //This function provides a reference to a lane in an AOSOA structure.
@@ -207,7 +203,6 @@ struct Voxels : IHomogeneousCompoundShape<Box, BoxWide>
     }
 
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly unsafe void FindLocalOverlaps<TOverlaps, TSubpairOverlaps>(ref Buffer<OverlapQueryForPair> pairs, BufferPool pool, Shapes shapes, ref TOverlaps overlaps)
          where TOverlaps : struct, ICollisionTaskOverlaps<TSubpairOverlaps>
          where TSubpairOverlaps : struct, ICollisionTaskSubpairOverlaps
@@ -228,7 +223,6 @@ struct Voxels : IHomogeneousCompoundShape<Box, BoxWide>
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly void FindLocalOverlaps<TEnumerator>(Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref TEnumerator enumerator)
         where TEnumerator : IBreakableForEach<int>
     {
@@ -264,7 +258,6 @@ public struct ConvexVoxelsContinuations : IConvexCompoundContinuationHandler<Non
 {
     public CollisionContinuationType CollisionContinuationType => CollisionContinuationType.NonconvexReduction;
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref NonconvexReduction CreateContinuation<TCallbacks>(
         ref CollisionBatcher<TCallbacks> collisionBatcher, int childCount, in BoundsTestedPair pair, in OverlapQueryForPair pairQuery, out int continuationIndex)
         where TCallbacks : struct, ICollisionCallbacks
@@ -272,7 +265,6 @@ public struct ConvexVoxelsContinuations : IConvexCompoundContinuationHandler<Non
         return ref collisionBatcher.NonconvexReductions.CreateContinuation(childCount, collisionBatcher.Pool, out continuationIndex);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void GetChildData<TCallbacks>(ref CollisionBatcher<TCallbacks> collisionBatcher, ref NonconvexReductionChild continuationChild,
         in BoundsTestedPair pair, int shapeTypeA, int childIndexB, out RigidPose childPoseB, out int childTypeB, out void* childShapeDataB)
         where TCallbacks : struct, ICollisionCallbacks
@@ -295,7 +287,6 @@ public struct ConvexVoxelsContinuations : IConvexCompoundContinuationHandler<Non
         collisionBatcher.CacheShapeB(shapeTypeA, childTypeB, Unsafe.AsPointer(ref halfSize), 12, out childShapeDataB);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe void ConfigureContinuationChild<TCallbacks>(
         ref CollisionBatcher<TCallbacks> collisionBatcher, ref NonconvexReduction continuation, int continuationChildIndex, in BoundsTestedPair pair, int shapeTypeA, int childIndexB,
         out RigidPose childPoseB, out int childTypeB, out void* childShapeDataB)
@@ -327,7 +318,6 @@ public unsafe struct CompoundVoxelsContinuations<TCompoundA> : ICompoundPairCont
 {
     public CollisionContinuationType CollisionContinuationType => CollisionContinuationType.NonconvexReduction;
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref NonconvexReduction CreateContinuation<TCallbacks>(
         ref CollisionBatcher<TCallbacks> collisionBatcher, int totalChildCount, ref Buffer<ChildOverlapsCollection> pairOverlaps, ref Buffer<OverlapQueryForPair> pairQueries, in BoundsTestedPair pair, out int continuationIndex)
         where TCallbacks : struct, ICollisionCallbacks
@@ -335,7 +325,6 @@ public unsafe struct CompoundVoxelsContinuations<TCompoundA> : ICompoundPairCont
         return ref collisionBatcher.NonconvexReductions.CreateContinuation(totalChildCount, collisionBatcher.Pool, out continuationIndex);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void GetChildAData<TCallbacks>(ref CollisionBatcher<TCallbacks> collisionBatcher, ref NonconvexReduction continuation, in BoundsTestedPair pair, int childIndexA,
         out RigidPose childPoseA, out int childTypeA, out void* childShapeDataA)
         where TCallbacks : struct, ICollisionCallbacks
@@ -347,7 +336,6 @@ public unsafe struct CompoundVoxelsContinuations<TCompoundA> : ICompoundPairCont
         collisionBatcher.Shapes[childTypeA].GetShapeData(compoundChildA.ShapeIndex.Index, out childShapeDataA, out _);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ConfigureContinuationChild<TCallbacks>(
         ref CollisionBatcher<TCallbacks> collisionBatcher, ref NonconvexReduction continuation, int continuationChildIndex, in BoundsTestedPair pair, int childIndexA, int childTypeA, int childIndexB, in RigidPose childPoseA,
         out RigidPose childPoseB, out int childTypeB, out void* childShapeDataB)

--- a/Demos/Demos/CustomVoxelCollidableDemo.cs
+++ b/Demos/Demos/CustomVoxelCollidableDemo.cs
@@ -228,6 +228,13 @@ struct Voxels : IHomogeneousCompoundShape<Box, BoxWide>
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly void FindLocalOverlaps<TEnumerator>(Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref TEnumerator enumerator)
+        where TEnumerator : IBreakableForEach<int>
+    {
+        Tree.GetOverlaps(min, max, pool, ref enumerator);
+    }
+
     public readonly unsafe void FindLocalOverlaps<TOverlaps>(Vector3 min, Vector3 max, Vector3 sweep, float maximumT, BufferPool pool, Shapes shapes, void* overlaps) where TOverlaps : ICollisionTaskSubpairOverlaps
     {
         //Similar to the non-swept FindLocalOverlaps function above, this just adds the overlaps to the provided collection.

--- a/Demos/SpecializedTests/CustomMeshSmoothingTestDemo.cs
+++ b/Demos/SpecializedTests/CustomMeshSmoothingTestDemo.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using BepuPhysics;
+using BepuPhysics.Collidables;
+using BepuPhysics.CollisionDetection;
+using BepuPhysics.CollisionDetection.CollisionTasks;
+using BepuPhysics.CollisionDetection.SweepTasks;
+using BepuPhysics.Constraints;
+using BepuPhysics.Trees;
+using BepuUtilities;
+using BepuUtilities.Collections;
+using BepuUtilities.Memory;
+using DemoContentLoader;
+using DemoRenderer;
+using DemoRenderer.UI;
+using DemoUtilities;
+
+namespace Demos.SpecializedTests;
+
+/// <summary>
+/// Pure forwarding wrapper around <see cref="Mesh"/>. Has its own TypeId so the narrow phase treats it as a distinct shape,
+/// which lets us verify that <see cref="MeshReduction"/>'s boundary smoothing works for any <see cref="IHomogeneousCompoundShape{Triangle, TriangleWide}">, not just the built-in Mesh type.
+/// </summary>
+public struct WrappedMesh : IHomogeneousCompoundShape<Triangle, TriangleWide>
+{
+    public Mesh Inner;
+
+    public WrappedMesh(Mesh inner)
+    {
+        Inner = inner;
+    }
+
+    public const int Id = 13;
+    public static int TypeId => Id;
+
+    public readonly int ChildCount => Inner.ChildCount;
+
+    public static ShapeBatch CreateShapeBatch(BufferPool pool, int initialCapacity, Shapes shapeBatches)
+    {
+        return new HomogeneousCompoundShapeBatch<WrappedMesh, Triangle, TriangleWide>(pool, initialCapacity);
+    }
+
+    public readonly void ComputeBounds(Quaternion orientation, out Vector3 min, out Vector3 max)
+    {
+        Inner.ComputeBounds(orientation, out min, out max);
+    }
+
+    public readonly void GetLocalChild(int childIndex, out Triangle target)
+    {
+        Inner.GetLocalChild(childIndex, out target);
+    }
+
+    public readonly void GetPosedLocalChild(int childIndex, out Triangle target, out RigidPose childPose)
+    {
+        Inner.GetPosedLocalChild(childIndex, out target, out childPose);
+    }
+
+    public readonly void GetLocalChild(int childIndex, ref TriangleWide target)
+    {
+        Inner.GetLocalChild(childIndex, ref target);
+    }
+
+    public readonly void RayTest<TRayHitHandler>(in RigidPose pose, in RayData ray, ref float maximumT, BufferPool pool, ref TRayHitHandler hitHandler)
+        where TRayHitHandler : struct, IShapeRayHitHandler
+    {
+        Inner.RayTest(pose, ray, ref maximumT, pool, ref hitHandler);
+    }
+
+    public readonly void RayTest<TRayHitHandler>(in RigidPose pose, ref RaySource rays, BufferPool pool, ref TRayHitHandler hitHandler)
+        where TRayHitHandler : struct, IShapeRayHitHandler
+    {
+        Inner.RayTest(pose, ref rays, pool, ref hitHandler);
+    }
+
+    public readonly unsafe void FindLocalOverlaps<TOverlaps, TSubpairOverlaps>(ref Buffer<OverlapQueryForPair> pairs, BufferPool pool, Shapes shapes, ref TOverlaps overlaps)
+        where TOverlaps : struct, ICollisionTaskOverlaps<TSubpairOverlaps>
+        where TSubpairOverlaps : struct, ICollisionTaskSubpairOverlaps
+    {
+        //Can't forward directly: the Mesh implementation reinterprets each pair.Container as Mesh*, but here the containers point to WrappedMesh instances.
+        //Replicate the loop and forward each pair's AABB to the inner mesh's single-AABB overload instead.
+        ShapeTreeOverlapEnumerator<TSubpairOverlaps> enumerator;
+        enumerator.Pool = pool;
+        for (int i = 0; i < pairs.Length; ++i)
+        {
+            ref var pair = ref pairs[i];
+            ref var wrapped = ref Unsafe.AsRef<WrappedMesh>(pair.Container);
+            enumerator.Overlaps = Unsafe.AsPointer(ref overlaps.GetOverlapsForPair(i));
+            wrapped.Inner.FindLocalOverlaps(pair.Min, pair.Max, pool, shapes, ref enumerator);
+        }
+    }
+
+    public readonly unsafe void FindLocalOverlaps<TOverlaps>(Vector3 min, Vector3 max, Vector3 sweep, float maximumT, BufferPool pool, Shapes shapes, void* overlaps)
+        where TOverlaps : ICollisionTaskSubpairOverlaps
+    {
+        Inner.FindLocalOverlaps<TOverlaps>(min, max, sweep, maximumT, pool, shapes, overlaps);
+    }
+
+    public readonly void FindLocalOverlaps<TEnumerator>(Vector3 min, Vector3 max, BufferPool pool, Shapes shapes, ref TEnumerator enumerator)
+        where TEnumerator : IBreakableForEach<int>
+    {
+        Inner.FindLocalOverlaps(min, max, pool, shapes, ref enumerator);
+    }
+
+    public void Dispose(BufferPool pool)
+    {
+        Inner.Dispose(pool);
+    }
+}
+
+/// <summary>
+/// Drops convex shapes onto two WrappedMesh heightfields side by side. The fine mesh (many small triangles) forces MeshReduction into its
+/// dictionary-based high-subpair-count path; the coarse mesh (few large triangles) keeps subpair counts under the brute-force threshold.
+/// Between them the demo exercises every branch of <see cref="MeshReduction.ReduceManifolds"/> for a non-<see cref="Mesh"/>
+/// IHomogeneousCompoundShape so boundary smoothing can be validated on the type-erased path.
+/// </summary>
+public class CustomMeshSmoothingTestDemo : Demo
+{
+    (StaticHandle Handle, Mesh InnerMesh)[] wrappedMeshes;
+
+    public override void Initialize(ContentArchive content, Camera camera)
+    {
+        camera.Position = new Vector3(0, 20, 60);
+        camera.Yaw = 0;
+        camera.Pitch = -0.3f;
+
+        Simulation = Simulation.Create(BufferPool, new DemoNarrowPhaseCallbacks(new SpringSettings(30, 1)), new DemoPoseIntegratorCallbacks(new Vector3(0, -10, 0)), new SolveDescription(8, 1));
+
+        //Register collision tasks for every convex shape we're going to drop against the WrappedMesh.
+        //These are the same tasks DefaultTypes registers for Mesh, just closed over WrappedMesh so MeshReductionThunks<WrappedMesh> is used instead of MeshReductionThunks<Mesh>.
+        var collisionTasks = Simulation.NarrowPhase.CollisionTaskRegistry;
+        collisionTasks.Register(new ConvexCompoundCollisionTask<Sphere, WrappedMesh, ConvexCompoundOverlapFinder<Sphere, SphereWide, WrappedMesh>, ConvexMeshContinuations<WrappedMesh>, MeshReduction>());
+        collisionTasks.Register(new ConvexCompoundCollisionTask<Capsule, WrappedMesh, ConvexCompoundOverlapFinder<Capsule, CapsuleWide, WrappedMesh>, ConvexMeshContinuations<WrappedMesh>, MeshReduction>());
+        collisionTasks.Register(new ConvexCompoundCollisionTask<Box, WrappedMesh, ConvexCompoundOverlapFinder<Box, BoxWide, WrappedMesh>, ConvexMeshContinuations<WrappedMesh>, MeshReduction>());
+        collisionTasks.Register(new ConvexCompoundCollisionTask<Triangle, WrappedMesh, ConvexCompoundOverlapFinder<Triangle, TriangleWide, WrappedMesh>, ConvexMeshContinuations<WrappedMesh>, MeshReduction>());
+        collisionTasks.Register(new ConvexCompoundCollisionTask<Cylinder, WrappedMesh, ConvexCompoundOverlapFinder<Cylinder, CylinderWide, WrappedMesh>, ConvexMeshContinuations<WrappedMesh>, MeshReduction>());
+        collisionTasks.Register(new ConvexCompoundCollisionTask<ConvexHull, WrappedMesh, ConvexCompoundOverlapFinder<ConvexHull, ConvexHullWide, WrappedMesh>, ConvexMeshContinuations<WrappedMesh>, MeshReduction>());
+
+        //Compound-vs-WrappedMesh uses a separate continuation type (CompoundMeshReduction), but it plugs into MeshReductionThunks<WrappedMesh> the same way.
+        collisionTasks.Register(new CompoundPairCollisionTask<Compound, WrappedMesh, CompoundPairOverlapFinder<Compound, WrappedMesh>, CompoundMeshContinuations<Compound, WrappedMesh>, CompoundMeshReduction>());
+
+        //Sweep tasks matching the convex set, so swept queries keep working too.
+        var sweepTasks = Simulation.NarrowPhase.SweepTaskRegistry;
+        sweepTasks.Register(new ConvexHomogeneousCompoundSweepTask<Sphere, SphereWide, WrappedMesh, Triangle, TriangleWide, ConvexCompoundSweepOverlapFinder<Sphere, WrappedMesh>>());
+        sweepTasks.Register(new ConvexHomogeneousCompoundSweepTask<Capsule, CapsuleWide, WrappedMesh, Triangle, TriangleWide, ConvexCompoundSweepOverlapFinder<Capsule, WrappedMesh>>());
+        sweepTasks.Register(new ConvexHomogeneousCompoundSweepTask<Box, BoxWide, WrappedMesh, Triangle, TriangleWide, ConvexCompoundSweepOverlapFinder<Box, WrappedMesh>>());
+        sweepTasks.Register(new ConvexHomogeneousCompoundSweepTask<Triangle, TriangleWide, WrappedMesh, Triangle, TriangleWide, ConvexCompoundSweepOverlapFinder<Triangle, WrappedMesh>>());
+        sweepTasks.Register(new ConvexHomogeneousCompoundSweepTask<Cylinder, CylinderWide, WrappedMesh, Triangle, TriangleWide, ConvexCompoundSweepOverlapFinder<Cylinder, WrappedMesh>>());
+        sweepTasks.Register(new ConvexHomogeneousCompoundSweepTask<ConvexHull, ConvexHullWide, WrappedMesh, Triangle, TriangleWide, ConvexCompoundSweepOverlapFinder<ConvexHull, WrappedMesh>>());
+        sweepTasks.Register(new CompoundHomogeneousCompoundSweepTask<Compound, WrappedMesh, Triangle, TriangleWide, CompoundPairSweepOverlapFinder<Compound, WrappedMesh>>());
+
+        //Two meshes that share the same world-space terrain shape and footprint, but with wildly different tessellation density.
+        //The fine mesh pushes subpair counts into the dictionary path; the coarse mesh keeps them in the brute-force path.
+        wrappedMeshes = new (StaticHandle, Mesh)[2];
+        var fineOrigin = Vector3.Zero;
+        var coarseOrigin = new Vector3(0, 0, 160);
+        AddWrappedTerrain(fineOrigin, planeWidth: 513, xzScale: 0.3f, out wrappedMeshes[0].Handle, out wrappedMeshes[0].InnerMesh);
+        AddShapesAt(fineOrigin);
+        AddWrappedTerrain(coarseOrigin, planeWidth: 33, xzScale: 4.8f, out wrappedMeshes[1].Handle, out wrappedMeshes[1].InnerMesh);
+        AddShapesAt(coarseOrigin);
+    }
+
+    void AddWrappedTerrain(Vector3 staticPosition, int planeWidth, float xzScale, out StaticHandle handle, out Mesh innerMesh)
+    {
+        //The noise is evaluated in mesh-local world space so both meshes end up with the same apparent terrain — only triangle density differs.
+        Vector2 terrainOffset = new Vector2(1 - planeWidth, 1 - planeWidth) * 0.5f;
+        var scale = new Vector3(xzScale, 0.1f, xzScale);
+        innerMesh = DemoMeshHelper.CreateDeformedPlane(planeWidth, planeWidth,
+            (int vX, int vY) =>
+            {
+                //vX and vY are vertex indices; multiply by scale after adding the centering offset to get a local-space position in world units.
+                var localX = (vX + terrainOffset.X) * xzScale;
+                var localZ = (vY + terrainOffset.Y) * xzScale;
+                var octave0 = (MathF.Sin((localX + 5f) * 0.133f) + MathF.Sin((localZ + 11) * 0.133f)) * 0.9f;
+                var octave1 = (MathF.Sin((localX + 17) * 0.367f) + MathF.Sin((localZ + 19) * 0.367f)) * 0.35f;
+                var octave2 = (MathF.Sin((localX + 37) * 0.767f) + MathF.Sin((localZ + 93) * 0.767f)) * 0.15f;
+                var terrainHeight = octave0 + octave1 + octave2;
+                return new Vector3(vX + terrainOffset.X, terrainHeight, vY + terrainOffset.Y);
+            }, scale, BufferPool);
+        var wrapped = new WrappedMesh(innerMesh);
+        handle = Simulation.Statics.Add(new StaticDescription(staticPosition, QuaternionEx.CreateFromAxisAngle(new Vector3(0, 1, 0), MathF.PI / 2), Simulation.Shapes.Add(wrapped)));
+    }
+
+    void AddShapesAt(Vector3 center)
+    {
+        //Wide, shallow shapes maximize the number of triangle AABBs intersecting the convex AABB on the fine mesh; on the coarse mesh the same shapes
+        //keep subpair counts well below MeshReduction's bruteForceThreshold of 128.
+
+        //1) Small box: fewer than 128 subpairs on either mesh.
+        {
+            var box = new Box(1.2f, 1.2f, 1.2f);
+            var shape = Simulation.Shapes.Add(box);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(-12, 4, 0), box.ComputeInertia(1), shape, 0.01f));
+        }
+
+        //2) Medium box: ~300-500 subpairs on the fine mesh (dictionary path), a handful on the coarse mesh.
+        {
+            var box = new Box(5f, 0.6f, 5f);
+            var shape = Simulation.Shapes.Add(box);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(-4, 4, 0), box.ComputeInertia(1), shape, 0.01f));
+        }
+
+        //3) Large box: ~800-1000 subpairs on the fine mesh, still close to the skip threshold.
+        {
+            var box = new Box(8f, 0.6f, 8f);
+            var shape = Simulation.Shapes.Add(box);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(6, 4, 0), box.ComputeInertia(1), shape, 0.01f));
+        }
+
+        //4) Oversized box: intentionally exceeds the 1024-subpair skip threshold on the fine mesh to confirm the fall-through doesn't crash.
+        {
+            var box = new Box(14f, 0.6f, 14f);
+            var shape = Simulation.Shapes.Add(box);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(18, 4, 0), box.ComputeInertia(1), shape, 0.01f));
+        }
+
+        //5) A few rounded shapes rolling across the bumpy surface. Boundary smoothing matters most when contacts straddle edges, so rollers are a good stress test.
+        {
+            var sphere = new Sphere(1.5f);
+            var shape = Simulation.Shapes.Add(sphere);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(-12, 6, 6), sphere.ComputeInertia(1), shape, 0.01f));
+
+            var cylinder = new Cylinder(2.5f, 1.5f);
+            var cylinderShape = Simulation.Shapes.Add(cylinder);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(-4, 6, 6), cylinder.ComputeInertia(1), cylinderShape, 0.01f));
+
+            var capsule = new Capsule(0.8f, 4f);
+            var capsuleShape = Simulation.Shapes.Add(capsule);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(6, 6, 6), capsule.ComputeInertia(1), capsuleShape, 0.01f));
+        }
+
+        //6) A Compound of a few boxes. This routes through CompoundMeshContinuations / CompoundMeshReduction instead of the convex-only MeshReduction path,
+        //   but it still feeds MeshReductionThunks<WrappedMesh>, so it's the complementary check that compound-vs-wrapped-mesh boundary smoothing works too.
+        {
+            var builder = new CompoundBuilder(BufferPool, Simulation.Shapes, 3);
+            builder.Add(new Box(3f, 0.5f, 3f), RigidPose.Identity, 1);
+            builder.Add(new Box(1.5f, 1.5f, 1.5f), new RigidPose(new Vector3(0, 1f, 0)), 1);
+            builder.Add(new Box(0.75f, 0.75f, 4f), new RigidPose(new Vector3(1.5f, 0.5f, 0)), 1);
+            builder.BuildDynamicCompound(out var children, out var compoundInertia);
+            builder.Dispose();
+            var compound = new Compound(children);
+            var shape = Simulation.Shapes.Add(compound);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(14, 8, -6), compoundInertia, shape, 0.01f));
+        }
+
+        //7) A wide, low convex hull. Hulls exercise a different convex-triangle tester than boxes, so including one catches regressions specific to hull-triangle manifolds.
+        {
+            const int hullPoints = 32;
+            var points = new QuickList<Vector3>(hullPoints, BufferPool);
+            var random = new Random(5);
+            for (int i = 0; i < hullPoints; ++i)
+            {
+                var xz = new Vector2(random.NextSingle() * 2 - 1, random.NextSingle() * 2 - 1);
+                //Flatten the hull so it covers a lot of ground when resting.
+                points.AllocateUnsafely() = new Vector3(xz.X * 3f, (random.NextSingle() * 2 - 1) * 0.35f, xz.Y * 3f);
+            }
+            var hull = new ConvexHull(points.Span.Slice(points.Count), BufferPool, out _);
+            var shape = Simulation.Shapes.Add(hull);
+            Simulation.Bodies.Add(BodyDescription.CreateDynamic(center + new Vector3(-4, 8, -6), hull.ComputeInertia(1), shape, 0.01f));
+        }
+    }
+
+    public override void Render(Renderer renderer, Camera camera, Input input, TextBuilder text, Font font)
+    {
+        //The renderer's shape extractor switch doesn't know about WrappedMesh, so add each inner Mesh directly at its static's pose.
+        //Using AddShape<Mesh> (rather than AddShape<WrappedMesh>) makes AddShape see Mesh.Id and routes to the existing mesh path.
+        foreach (var (handle, innerMesh) in wrappedMeshes)
+        {
+            ref var pose = ref Simulation.Statics[handle].Pose;
+            renderer.Shapes.AddShape(innerMesh, Simulation.Shapes, pose, new Vector3(0.7f, 0.7f, 0.75f));
+        }
+
+        var resolution = renderer.Surface.Resolution;
+        renderer.TextBatcher.Write(text.Clear().Append("Two WrappedMesh terrains: fine (near) and coarse (far, +Z). Identical shapes are dropped on each."), new Vector2(16, resolution.Y - 80), 16, Vector3.One, font);
+        renderer.TextBatcher.Write(text.Clear().Append("Fine mesh pushes MeshReduction into its dictionary path; coarse mesh keeps everything in the brute-force path."), new Vector2(16, resolution.Y - 64), 16, Vector3.One, font);
+        renderer.TextBatcher.Write(text.Clear().Append("Note: the largest box on the fine mesh overlaps more than 1024 triangles, so MeshReduction.ReduceManifolds early-outs"), new Vector2(16, resolution.Y - 40), 16, Vector3.One, font);
+        renderer.TextBatcher.Write(text.Clear().Append("and no boundary smoothing is applied to it. Expect visible bumps there; the coarse-mesh counterpart still smooths."), new Vector2(16, resolution.Y - 24), 16, Vector3.One, font);
+        base.Render(renderer, camera, input, text, font);
+    }
+}


### PR DESCRIPTION
Historically, `MeshReduction` was hardcoded to work only with `Mesh`. This expands support with some function pointer hackery to anything obeying the interface.

Also, fixed a latent bug in mesh collisions that had >128 child pairs and nonunit scaling on the mesh, oops. That would have basically disabled smoothing for those pairs.