### PR TITLE
Allow leaf nodes in ray cast

### DIFF
--- a/BepuPhysics/Trees/Tree_RayCast.cs
+++ b/BepuPhysics/Trees/Tree_RayCast.cs
@@ -27,7 +27,7 @@ namespace BepuPhysics.Trees
         internal readonly unsafe void RayCast<TLeafTester>(int nodeIndex, TreeRay* treeRay, RayData* rayData, Buffer<int> stack, BufferPool pool, ref TLeafTester leafTester) where TLeafTester : IRayLeafTester
         {
             Debug.Assert((nodeIndex >= 0 && nodeIndex < NodeCount) || (Encode(nodeIndex) >= 0 && Encode(nodeIndex) < LeafCount));
-            Debug.Assert(LeafCount >= 2, "This implementation assumes all nodes are filled.");
+            Debug.Assert(LeafCount >= 2 || nodeIndex < 0, "The node traversal assumes all nodes are filled; a single-leaf tree can only be entered through its encoded leaf index.");
 
             int stackEnd = 0;
             while (true)

--- a/BepuPhysics/Trees/Tree_Sweep.cs
+++ b/BepuPhysics/Trees/Tree_Sweep.cs
@@ -15,7 +15,7 @@ namespace BepuPhysics.Trees
         readonly unsafe void Sweep<TLeafTester>(int nodeIndex, Vector3 expansion, Vector3 origin, Vector3 direction, TreeRay* treeRay, Buffer<int> stack, BufferPool pool, ref TLeafTester leafTester) where TLeafTester : ISweepLeafTester
         {
             Debug.Assert((nodeIndex >= 0 && nodeIndex < NodeCount) || (Encode(nodeIndex) >= 0 && Encode(nodeIndex) < LeafCount));
-            Debug.Assert(LeafCount >= 2, "This implementation assumes all nodes are filled.");
+            Debug.Assert(LeafCount >= 2 || nodeIndex < 0, "The node traversal assumes all nodes are filled; a single-leaf tree can only be entered through its encoded leaf index.");
 
             int stackEnd = 0;
             while (true)

--- a/BepuPhysics/Trees/Tree_VolumeQuery.cs
+++ b/BepuPhysics/Trees/Tree_VolumeQuery.cs
@@ -11,7 +11,7 @@ namespace BepuPhysics.Trees
         unsafe readonly void GetOverlaps<TEnumerator>(int nodeIndex, BoundingBox boundingBox, Buffer<int> stack, BufferPool pool, ref TEnumerator leafEnumerator) where TEnumerator : IBreakableForEach<int>
         {
             Debug.Assert((nodeIndex >= 0 && nodeIndex < NodeCount) || (Encode(nodeIndex) >= 0 && Encode(nodeIndex) < LeafCount));
-            Debug.Assert(LeafCount >= 2, "This implementation assumes all nodes are filled.");
+            Debug.Assert(LeafCount >= 2 || nodeIndex < 0, "The node traversal assumes all nodes are filled; a single-leaf tree can only be entered through its encoded leaf index.");
 
             int stackEnd = 0;
             while (true)


### PR DESCRIPTION
Debug asserts no longer fire when passing a leaf index to the tree traversals. This fixes #408's issue observed on eeny weeny trees.