### PR TITLE
Improve TypedIndex (and similar) performance

### DIFF
--- a/BepuPhysics/Collidables/BoundingBoxBatcher.cs
+++ b/BepuPhysics/Collidables/BoundingBoxBatcher.cs
@@ -9,11 +9,11 @@ using System.Runtime.CompilerServices;
 
 namespace BepuPhysics
 {
-    public struct BoundsContinuation
+    public readonly struct BoundsContinuation
     {
         //Bits 0-30: body index
         //Bit 31: compound flag; if set, the continuation should merge into the target slot rather than merely setting it.
-        uint packed;
+        readonly uint packed;
 
         /// <summary>
         /// Gets the index of the body associated with this continuation.
@@ -39,6 +39,12 @@ namespace BepuPhysics
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private BoundsContinuation(uint packed)
+        {
+            this.packed = packed;
+        }
+
         /// <summary>
         /// Creates a bounding box calculation continuation for a given noncompound body.
         /// </summary>
@@ -46,9 +52,7 @@ namespace BepuPhysics
         public static BoundsContinuation CreateContinuation(int bodyIndex)
         {
             Debug.Assert(bodyIndex >= 0);
-            BoundsContinuation toReturn;
-            toReturn.packed = (uint)bodyIndex;
-            return toReturn;
+            return new BoundsContinuation((uint)bodyIndex);
         }
         /// <summary>
         /// Creates a bounding box calculation continuation for a given compound body.
@@ -57,9 +61,7 @@ namespace BepuPhysics
         public static BoundsContinuation CreateCompoundChildContinuation(int compoundBodyIndex)
         {
             Debug.Assert(compoundBodyIndex >= 0);
-            BoundsContinuation toReturn;
-            toReturn.packed = (1u << 31) | (uint)compoundBodyIndex;
-            return toReturn;
+            return new BoundsContinuation((1u << 31) | (uint)compoundBodyIndex);
         }
     }
 

--- a/BepuPhysics/Collidables/CollidableReference.cs
+++ b/BepuPhysics/Collidables/CollidableReference.cs
@@ -29,12 +29,12 @@ namespace BepuPhysics.Collidables
     /// Uses a bitpacked representation to refer to a body or static collidable.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, Size = 4)]
-    public struct CollidableReference : IEquatable<CollidableReference>
+    public readonly struct CollidableReference : IEquatable<CollidableReference>
     {
         /// <summary>
         /// Bitpacked representation of the collidable reference.
         /// </summary>
-        public uint Packed;
+        public readonly uint Packed;
 
         /// <summary>
         /// Gets the mobility state of the owner of this collidable.

--- a/BepuPhysics/Collidables/TypedIndex.cs
+++ b/BepuPhysics/Collidables/TypedIndex.cs
@@ -7,12 +7,12 @@ namespace BepuPhysics.Collidables
     /// <summary>
     /// Represents an index with an associated type packed into a single integer.
     /// </summary>
-    public struct TypedIndex : IEquatable<TypedIndex>
+    public readonly struct TypedIndex : IEquatable<TypedIndex>
     {
         /// <summary>
         /// Bit packed representation of the typed index.
         /// </summary>
-        public uint Packed;
+        public readonly uint Packed;
 
         /// <summary>
         /// Gets the type index of the object.
@@ -38,7 +38,7 @@ namespace BepuPhysics.Collidables
         public bool Exists
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get { return (Packed & (1 << 31)) > 0; }
+            get { return (Packed & (1u << 31)) > 0; }
         }
         
         public TypedIndex(int type, int index)
@@ -48,7 +48,7 @@ namespace BepuPhysics.Collidables
             //Note the inclusion of a set bit in the most significant slot.
             //This encodes that the index was explicitly constructed, so it is a 'real' reference.
             //A default constructed TypeIndex will have a 0 in the MSB, so we can use the default constructor for empty references.
-            Packed = (uint)((type << 24) | index | (1u << 31));
+            Packed =((uint)type << 24) | (uint)index | (1u << 31);
         }
 
         public override string ToString()

--- a/BepuPhysics/Collidables/TypedIndex.cs
+++ b/BepuPhysics/Collidables/TypedIndex.cs
@@ -48,7 +48,7 @@ namespace BepuPhysics.Collidables
             //Note the inclusion of a set bit in the most significant slot.
             //This encodes that the index was explicitly constructed, so it is a 'real' reference.
             //A default constructed TypeIndex will have a 0 in the MSB, so we can use the default constructor for empty references.
-            Packed =((uint)type << 24) | (uint)index | (1u << 31);
+            Packed = ((uint)type << 24) | (uint)index | (1u << 31);
         }
 
         public override string ToString()

--- a/BepuPhysics/CollisionDetection/CollisionBatcherContinuations.cs
+++ b/BepuPhysics/CollisionDetection/CollisionBatcherContinuations.cs
@@ -77,12 +77,12 @@ namespace BepuPhysics.CollisionDetection
 
     }
 
-    public struct PairContinuation
+    public readonly struct PairContinuation
     {
-        public int PairId;
-        public int ChildA;
-        public int ChildB;
-        public uint Packed;
+        public readonly int PairId;
+        public readonly int ChildA;
+        public readonly int ChildB;
+        public readonly uint Packed;
 
         /// <summary>
         /// Covers bits [0, 20) in the packed representation. Refers to the child pair index in a subtask generating collision task that generated this continuation.

--- a/BepuPhysics/CollisionDetection/ContinuationIndex.cs
+++ b/BepuPhysics/CollisionDetection/ContinuationIndex.cs
@@ -3,9 +3,9 @@ using System.Runtime.CompilerServices;
 
 namespace BepuPhysics.CollisionDetection
 {
-    public struct CCDContinuationIndex
+    public readonly struct CCDContinuationIndex
     {
-        public uint Packed;
+        public readonly uint Packed;
 
         //From least to most significant: 30 bits index, 1 bit type, 1 bit 'exists' flag.
 
@@ -33,7 +33,7 @@ namespace BepuPhysics.CollisionDetection
         public bool Exists
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get { return (Packed & (1 << 31)) > 0; }
+            get { return (Packed & (1u << 31)) > 0; }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -44,7 +44,7 @@ namespace BepuPhysics.CollisionDetection
             //Note the inclusion of a set bit in the most significant slot.
             //This encodes that the index was explicitly constructed, so it is a 'real' reference.
             //A default constructed TypeIndex will have a 0 in the MSB, so we can use the default constructor for empty references.
-            Packed = (uint)((type << 30) | index | (1u << 31));
+            Packed = ((uint)type << 30) | (uint)index | (1u << 31);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public CCDContinuationIndex(int packed)

--- a/BepuPhysics/Trees/Leaf.cs
+++ b/BepuPhysics/Trees/Leaf.cs
@@ -7,7 +7,7 @@ namespace BepuPhysics.Trees
     /// Pointer to a leaf's tree location.
     /// </summary>
     /// <remarks>The identity of a leaf is implicit in its position within the leaf array.</remarks>
-    public struct Leaf
+    public readonly struct Leaf
     {
         /// <summary>
         /// Gets the index of the node that the leaf is directly held by.
@@ -26,7 +26,7 @@ namespace BepuPhysics.Trees
             get { return (int)((packed & 0x80000000) >> 31); }
         }
 
-        uint packed;
+        readonly uint packed;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Leaf(int nodeIndex, int childIndex)


### PR DESCRIPTION
Applying `readonly` to a struct prevents the compiler from generating defensive copies.

I also found some code in these structs using 64 bit signed integers instead of 32 bit unsigned integers.

See: https://devblogs.microsoft.com/premier-developer/avoiding-struct-and-readonly-reference-performance-pitfalls-with-errorprone-net/